### PR TITLE
Add autotools required to generate configure scripts

### DIFF
--- a/bosh-stemcell/spec/os_image/centos_7_spec.rb
+++ b/bosh-stemcell/spec/os_image/centos_7_spec.rb
@@ -25,6 +25,7 @@ describe 'CentOS 7 OS image', os_image: true do
 
   context 'installed by base_centos_packages' do
     %w(
+      automake
       bison
       bzip2-devel
       cloud-utils-growpart
@@ -38,12 +39,14 @@ describe 'CentOS 7 OS image', os_image: true do
       glibc-static
       iptables
       libcap-devel
+      libtool
       libuuid-devel
       libxml2
       libxml2-devel
       libxslt
       libxslt-devel
       lsof
+      m4
       NetworkManager
       net-tools
       nmap-ncat

--- a/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
@@ -124,6 +124,8 @@ describe 'Ubuntu 14.04 OS image', os_image: true do
     %w(
       anacron
       apparmor-utils
+      autoconf
+      automake
       bind9-host
       bison
       cloud-guest-utils
@@ -147,11 +149,13 @@ describe 'Ubuntu 14.04 OS image', os_image: true do
       libpam-cracklib
       libreadline6-dev
       libssl-dev
+      libtool
       libxml2
       libxml2-dev
       libxslt1-dev
       libxslt1.1
       lsof
+      m4
       mg
       module-assistant
       nfs-common

--- a/stemcell_builder/stages/base_centos_packages/apply.sh
+++ b/stemcell_builder/stages/base_centos_packages/apply.sh
@@ -33,6 +33,7 @@ nfs-common flex psmisc apparmor-utils iptables sysstat \
 rsync openssh-server traceroute libncurses5-devs \
 libaio1 gdb libcap2-bin libcap-devel bzip2-devel \
 cmake sudo libuuid-devel parted NetworkManager e2fsprogs cloud-utils-growpart \
+automake libtool m4 \
 xfsprogs gdisk"
 pkg_mgr install ${packages} ${version_specific_packages}
 

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -14,6 +14,7 @@ libaio1 gdb libcap2-bin libcap2-dev libbz2-dev \
 cmake uuid-dev libgcrypt-dev ca-certificates \
 scsitools mg htop module-assistant debhelper runit parted \
 cloud-guest-utils anacron software-properties-common \
+autoconf automake libtool m4 \
 xfsprogs gdisk libpam-cracklib"
 
 if is_ppc64le; then

--- a/stemcell_builder/stages/dev_tools_config/assets/generate_dev_tools_file_list_centos.sh
+++ b/stemcell_builder/stages/dev_tools_config/assets/generate_dev_tools_file_list_centos.sh
@@ -2,6 +2,7 @@
 
 for package_name in \
   autoconf \
+  automake \
   bison \
   cmake \
   cpp \
@@ -14,6 +15,8 @@ for package_name in \
   libmpc \
   libquadmath-devel \
   libstdc++-devel \
+  libtool \
+  m4 \
   make \
   patch \
 ; do

--- a/stemcell_builder/stages/dev_tools_config/assets/generate_dev_tools_file_list_ubuntu.sh
+++ b/stemcell_builder/stages/dev_tools_config/assets/generate_dev_tools_file_list_ubuntu.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 for package_name in \
+  autoconf \
+  automake \
   binutils \
   bison \
   build-essential \
@@ -18,6 +20,8 @@ for package_name in \
   gettext \
   intltool-debian \
   libmpc3 \
+  libtool \
+  m4 \
   make \
   patch \
   po-debconf \


### PR DESCRIPTION
To compile Erlang from the official Github repository, we need to
generate the configure script before we can run ./configure. It's the
same for any project based on autotools.

Signed-off-by: Gerhard Lazu <gerhard@rabbitmq.com>