### PR TITLE
Fix filename of stemcells downloaded with curl

### DIFF
--- a/ci/tasks/publish.sh
+++ b/ci/tasks/publish.sh
@@ -9,10 +9,11 @@ for file in $COPY_KEYS ; do
   file="${file/\%s/$VERSION}"
 
   echo "$file"
+  filename=$(${file} | grep -E -o 'bosh-stemcell.*.tgz' )
 
   # occasionally this fails for unexpected reasons; retry a few times
   for i in {1..4}; do
-    aws s3 cp "s3://$CANDIDATE_BUCKET_NAME/$file" "s3://$PUBLISHED_BUCKET_NAME/$file" \
+    aws s3 cp --content-disposition filename=${filename} --metadata-directive REPLACE "s3://$CANDIDATE_BUCKET_NAME/$file" "s3://$PUBLISHED_BUCKET_NAME/$file" \
       && break \
       || sleep 5
   done

--- a/ci/tasks/publish.sh
+++ b/ci/tasks/publish.sh
@@ -9,7 +9,7 @@ for file in $COPY_KEYS ; do
   file="${file/\%s/$VERSION}"
 
   echo "$file"
-  filename=$(${file} | grep -E -o 'bosh-stemcell.*.tgz' )
+  filename=$(basename "$file")
 
   # occasionally this fails for unexpected reasons; retry a few times
   for i in {1..4}; do


### PR DESCRIPTION
Currently we tell the user to download stemcells from bosh.io with this command:
```
curl -L -J -O https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-trusty-go_agent?v=3421.9
```
This leads to a file on our disk with the name `bosh-openstack-kvm-ubuntu-trusty-go_agent?v=3421.9` and not `bosh-stemcell-3421.9-openstack-kvm-ubuntu-7-go_agent.tgz` as it was intended. Clicking the download link on bosh.io will download with the correct filename. 

The `content-disposition` http header is used to set the filename when using
`curl -J -O` which at the moment was missing from our stemcells on S3.

[#147759327](https://www.pivotaltracker.com/story/show/147759327)

Signed-off-by: Mauro Morales <mamorales@suse.com>