### PR TITLE
Support CustomScript extension on Azure

### DIFF
--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -27,6 +27,7 @@ run_in_chroot $chroot "
   cd WALinuxAgent-${wala_release}
   sudo python setup.py install --skip-data-files
   cp bin/waagent /usr/sbin/waagent
+  cp bin/waagent2.0 /usr/sbin/waagent2.0
   chmod 0755 /usr/sbin/waagent
   cd /tmp/
   sudo rm -fr WALinuxAgent-${wala_release}


### PR DESCRIPTION
Current Azure stemcells does not support to install CustomScript extension because of missing the file waagent2.0. So you will get a similar error as below if you want to install CustomScript extensions in Azure VMs which are created by BOSH.

```
Traceback (most recent call last):
  File "./customscript.py", line 33, in <module>
    from Utils.WAAgentUtil import waagent
  File "/var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux-1.5.2.1/Utils/WAAgentUtil.py", line 42, in <module>
    waagent = imp.load_source('waagent', agentPath)
  File "/usr/sbin/waagent", line 46, in <module>
    raise ImportError("Can't load waagent")
ImportError: Can't load waagent
```