### PR TITLE
Add second settings source to warden agent.json.

### DIFF
--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -75,6 +75,10 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
         {
           "Type": "File",
           "SettingsPath": "/var/vcap/bosh/warden-cpi-agent-env.json"
+        },
+        {
+          "Type": "File",
+          "SettingsPath": "/var/vcap/bosh/settings-source-file/config.json"
         }
       ]
     }


### PR DESCRIPTION
Kubernetes only updates secrets/config mounted as directory.
In order to use a plain warden stemcell for the Kubernetes CPI
we need to hook in a settings source pointing to a file that will
be the only file in that folder.