### PR TITLE
stemcell_builder: Include google_gcscli in Google stemcell

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -141,6 +141,7 @@ module Bosh::Stemcell
 
     def google_stages
       [
+        :google_gcscli,
         :system_network,
         :system_google_modules,
         :system_google_packages,

--- a/stemcell_builder/stages/google_gcscli/apply.sh
+++ b/stemcell_builder/stages/google_gcscli/apply.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/lib/prelude_bosh.bash
+
+cd $assets_dir/gcscli
+mv gcscli $chroot/var/vcap/bosh/bin/bosh-blobstore-gcs
+chmod +x $chroot/var/vcap/bosh/bin/bosh-blobstore-gcs

--- a/stemcell_builder/stages/google_gcscli/config.sh
+++ b/stemcell_builder/stages/google_gcscli/config.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_config.bash
+
+# Download CLI source or release from github into assets directory
+cd $assets_dir
+rm -rf gcscli
+mkdir gcscli
+current_version=0.0.2
+
+curl -L -o gcscli/gcscli https://s3.amazonaws.com/bosh-gcscli/bosh-gcscli-${current_version}-linux-amd64
+echo "a151d3829f53b68bd15edfd3e6a527d187591992 gcscli/gcscli" | sha1sum -c -


### PR DESCRIPTION
This change adds the google_gcscli tool to the Google stemcell to
support GCS as a native blobstore.

cc @evandbrown