### PR TITLE
rsyslogd should not query root zone regularly

### DIFF
--- a/stemcell_builder/stages/rsyslog_config/assets/rsyslog.conf
+++ b/stemcell_builder/stages/rsyslog_config/assets/rsyslog.conf
@@ -5,6 +5,8 @@
 #
 #  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
 
+global(net.enableDNS="off")
+global(net.aclResolveHostname="off")
 
 #################
 #### MODULES ####


### PR DESCRIPTION
Each VM deployed by BOSH performs multiple DNS root queries every 30
seconds. It turned out that rsyslogd is performing these queries. In
larger system these queries sum up to a remarkable amount.

This change prevents rsyslogd to query the DNS root zone constantly.