### PR TITLE
Fix for enabling XFS on ubuntu trusty stem cells on Google KVM 

### DIFF
--- a/stemcell_builder/lib/prelude_agent.bash
+++ b/stemcell_builder/lib/prelude_agent.bash
@@ -6,3 +6,11 @@ function get_partitioner_type_mapping {
       echo ''
   fi
 }
+
+function get_google_partitioner_type_mapping {
+  if [ "$(get_os_type)" == "opensuse" ] || ( [ "$(get_os_type)" == "ubuntu" ] && [ "${DISTRIB_CODENAME}" == "xenial" ]) || ( [ "$(get_os_type)" == "ubuntu" ] && [ "${DISTRIB_CODENAME}" == "trusty" ]); then
+      echo '"PartitionerType": "parted",'
+  else
+      echo ''
+  fi
+}

--- a/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
@@ -9,7 +9,7 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
   "Platform": {
     "Linux": {
       "CreatePartitionIfNoEphemeralDisk": true,
-      $(get_partitioner_type_mapping)
+      $(get_google_partitioner_type_mapping)
       "DevicePathResolutionType": "virtio",
       "VirtioDevicePrefix": "google"
     }


### PR DESCRIPTION
https://github.com/cloudfoundry/bosh/issues/1722

This issue is currently blocking multiple users from installing XFS filesystems on Ubuntu Trusty stem cells on Google Cloud VMs.
The only workaround for this has been to use persistent disks greater than 2TB. This solution might not be workable for all cases.

This change will make parted as the default FS partitioner on trusty images on Google Cloud.