### PR TITLE
Support Azure serial console

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -173,6 +173,7 @@ module Bosh::Stemcell
       [
         :system_azure_network,
         :system_azure_wala,
+        :system_azure_serial_console,
         :system_parameters,
         :enable_udf_module,
         :bosh_clean,

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -405,6 +405,7 @@ module Bosh::Stemcell
           [
             :system_azure_network,
             :system_azure_wala,
+            :system_azure_serial_console,
             :system_parameters,
             :enable_udf_module,
             :bosh_clean,

--- a/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
@@ -345,6 +345,39 @@ HERE
       end
     end
   end
+
+  context 'installed by system_azure_serial_console', {
+    exclude_on_aws: true,
+    exclude_on_google: true,
+    exclude_on_vcloud: true,
+    exclude_on_vsphere: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+    exclude_on_softlayer: true,
+  } do
+    describe file('/etc/init/ttyS0.conf') do
+      it { should be_file }
+      its(:content) { should eql(<<HERE) }
+# ttyS0 - getty
+#
+# This service maintains a getty on ttyS0 from the point the system is
+# started until it is shut down again.
+
+start on stopped rc RUNLEVEL=[12345]
+stop on runlevel [!12345]
+
+pre-start script
+    # getty will not be started if the serial console is not present
+    stty -F /dev/ttyS0 -a 2> /dev/null > /dev/null || { stop; exit 0; }
+end script
+
+respawn
+script
+    exec /sbin/getty -L ttyS0 115200 vt102
+end script
+HERE
+    end
+  end
 end
 
 describe 'Ubuntu 14.04 stemcell tarball', stemcell_tarball: true do

--- a/bosh-stemcell/spec/stemcells/ubuntu_xenial_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_xenial_spec.rb
@@ -353,39 +353,6 @@ HERE
       end
     end
   end
-
-  context 'installed by system_azure_serial_console', {
-    exclude_on_aws: true,
-    exclude_on_google: true,
-    exclude_on_vcloud: true,
-    exclude_on_vsphere: true,
-    exclude_on_warden: true,
-    exclude_on_openstack: true,
-    exclude_on_softlayer: true,
-  } do
-    describe file('/etc/init/ttyS0.conf') do
-      it { should be_file }
-      its(:content) { should eql(<<HERE) }
-# ttyS0 - getty
-#
-# This service maintains a getty on ttyS0 from the point the system is
-# started until it is shut down again.
-
-start on stopped rc RUNLEVEL=[12345]
-stop on runlevel [!12345]
-
-pre-start script
-    # getty will not be started if the serial console is not present
-    stty -F /dev/ttyS0 -a 2> /dev/null > /dev/null || { stop; exit 0; }
-end script
-
-respawn
-script
-    exec /sbin/getty -L ttyS0 115200 vt102
-end script
-HERE
-    end
-  end
 end
 
 describe 'Ubuntu 16.04 stemcell tarball', stemcell_tarball: true do

--- a/bosh-stemcell/spec/stemcells/ubuntu_xenial_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_xenial_spec.rb
@@ -353,6 +353,39 @@ HERE
       end
     end
   end
+
+  context 'installed by system_azure_serial_console', {
+    exclude_on_aws: true,
+    exclude_on_google: true,
+    exclude_on_vcloud: true,
+    exclude_on_vsphere: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+    exclude_on_softlayer: true,
+  } do
+    describe file('/etc/init/ttyS0.conf') do
+      it { should be_file }
+      its(:content) { should eql(<<HERE) }
+# ttyS0 - getty
+#
+# This service maintains a getty on ttyS0 from the point the system is
+# started until it is shut down again.
+
+start on stopped rc RUNLEVEL=[12345]
+stop on runlevel [!12345]
+
+pre-start script
+    # getty will not be started if the serial console is not present
+    stty -F /dev/ttyS0 -a 2> /dev/null > /dev/null || { stop; exit 0; }
+end script
+
+respawn
+script
+    exec /sbin/getty -L ttyS0 115200 vt102
+end script
+HERE
+    end
+  end
 end
 
 describe 'Ubuntu 16.04 stemcell tarball', stemcell_tarball: true do

--- a/stemcell_builder/stages/system_azure_serial_console/apply.sh
+++ b/stemcell_builder/stages/system_azure_serial_console/apply.sh
@@ -5,7 +5,7 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-if [ "$(get_os_type)" == "ubuntu" ]; then
+if [ ${DISTRIB_CODENAME} == 'trusty' ]; then
   cat >> $chroot/etc/init/ttyS0.conf <<EOS
 # ttyS0 - getty
 #

--- a/stemcell_builder/stages/system_azure_serial_console/apply.sh
+++ b/stemcell_builder/stages/system_azure_serial_console/apply.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+
+if [ "$(get_os_type)" == "ubuntu" ]; then
+  cat >> $chroot/etc/init/ttyS0.conf <<EOS
+# ttyS0 - getty
+#
+# This service maintains a getty on ttyS0 from the point the system is
+# started until it is shut down again.
+
+start on stopped rc RUNLEVEL=[12345]
+stop on runlevel [!12345]
+
+pre-start script
+    # getty will not be started if the serial console is not present
+    stty -F /dev/ttyS0 -a 2> /dev/null > /dev/null || { stop; exit 0; }
+end script
+
+respawn
+script
+    exec /sbin/getty -L ttyS0 115200 vt102
+end script
+EOS
+fi


### PR DESCRIPTION
This PR is to enable serial console on hyper-v ubuntu stemcells.

[Serial console](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/serial-console) is a very good feature for diagnostics, with which users can still operate the VM even if they can't (bosh) ssh to the VM. Many people like this feature.

