### PR TITLE
update Windows Azure Linux Agent, enable extensions support, and switch to use systemd for windows azure linux agent.

### DIFF
--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -8,8 +8,8 @@ source $base_dir/lib/prelude_apply.bash
 packages="python python-pyasn1 python-setuptools"
 pkg_mgr install $packages
 
-wala_release=2.2.16 
-wala_expected_sha1=7c814b6814dee104684e43fb144bcc5ce82f8225
+wala_release=2.2.25
+wala_expected_sha1=8fb9ef0558c11b70b48188fb5afd53eadc321fac
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')
@@ -26,22 +26,26 @@ run_in_chroot $chroot "
   tar zxvf wala.tar.gz
   cd WALinuxAgent-${wala_release}
   sudo python setup.py install --skip-data-files
-  cp bin/waagent /usr/sbin/waagent
-  chmod 0755 /usr/sbin/waagent
+  cp bin/waagent* /usr/sbin/
+  chmod 0755 /usr/sbin/waagent*
   cd /tmp/
   sudo rm -fr WALinuxAgent-${wala_release}
   rm wala.tar.gz
 "
-
 cp -f $dir/assets/etc/waagent.conf $chroot/etc/waagent.conf
 
-cp -a $dir/assets/runit/waagent $chroot/etc/sv/waagent
-
-# Set up waagent with runit
-run_in_chroot $chroot "
-chmod +x /etc/sv/waagent/run
-ln -s /etc/sv/waagent /etc/service/waagent
-"
+if [ ${DISTRIB_CODENAME} == 'trusty' ]; then
+  cp -a $dir/assets/runit/waagent $chroot/etc/sv/waagent
+  # Set up waagent with runit
+  run_in_chroot $chroot "
+  chmod +x /etc/sv/waagent/run
+  ln -s /etc/sv/waagent /etc/service/waagent
+  "
+else
+  cp -f $dir/assets/etc/walinuxagent.service $chroot/lib/systemd/system/walinuxagent.service
+  chmod 0755 $chroot/lib/systemd/system/walinuxagent.service
+  run_in_chroot $chroot "systemctl enable walinuxagent.service"
+fi
 
 cat > $chroot/etc/logrotate.d/waagent <<EOS
 /var/log/waagent.log {

--- a/stemcell_builder/stages/system_azure_wala/assets/etc/walinuxagent.service
+++ b/stemcell_builder/stages/system_azure_wala/assets/etc/walinuxagent.service
@@ -1,0 +1,22 @@
+#
+# NOTE:
+#   This file hosted on WALinuxAgent repository only for reference purposes.
+#   Please refer to a recent image to find out the up-to-date systemd unit file.
+#
+
+[Unit]
+Description=Azure Linux Agent
+
+After=network-online.target
+Wants=network-online.target
+
+ConditionFileIsExecutable=/usr/sbin/waagent
+ConditionPathExists=/etc/waagent.conf
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python -u /usr/sbin/waagent -daemon
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
1. updated the Windows Azure Linux Agent to 2.25.
2. copy the waagent2.0 file to support the extensions.
3. switch to use the systemd, because the Windows Azure Linux Agent are using it, to make it more compatable if there's any change in the future.

use the systemd can help manage the service dependency relation, say the wala should wait for the network-online.target.