### PR TITLE
Set 25G disk for Softlayer stemcell

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
@@ -185,7 +185,7 @@ module Bosh::Stemcell
         super(
           name: 'softlayer',
           hypervisor: 'esxi',
-          default_disk_size: 3072,
+          default_disk_size: 25600,
           disk_formats: ['ovf'],
           stemcell_formats: ['softlayer-ovf']
         )

--- a/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
@@ -172,7 +172,7 @@ module Bosh::Stemcell
   describe Infrastructure::Softlayer do
     its(:name)              { should eq('softlayer') }
     its(:hypervisor)        { should eq('esxi') }
-    its(:default_disk_size) { should eq(3072) }
+    its(:default_disk_size) { should eq(25600) }
     its(:disk_formats)      { should eq(['ovf']) }
     its(:stemcell_formats)  { should eq(['softlayer-ovf']) }
 


### PR DESCRIPTION
For Softlayer, the VM system disk is always allocated to 25G, we need to change the SL stemcell disk size to 25G accordingly. It doesn't save money even if you only use 3G system disk. Especially for our Bluemix environment, there are some virus scan tools which have to be installed on the system disk, so 3G system disk is not enough.