### PR TITLE
install the qemu-utils package for the stemcell for azure.

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -201,6 +201,7 @@ module Bosh::Stemcell
         :system_azure_network,
         :system_azure_wala,
         :system_parameters,
+        :bosh_azure_config_disk_packages,
         :enable_udf_module,
         :bosh_clean,
         :bosh_harden,

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-trusty-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-trusty-azure-additions.txt
@@ -1,3 +1,11 @@
 python-pkg-resources
 python-pyasn1
 python-setuptools
+libboost-system1.54.0:amd64
+libboost-thread1.54.0:amd64
+libnspr4:amd64
+libnss3:amd64
+libnss3-nssdb
+librados2
+librbd1
+qemu-utils

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-xenial-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-xenial-azure-additions.txt
@@ -8,3 +8,11 @@ python-pyasn1
 python-setuptools
 python2.7
 python2.7-minimal
+libboost-system1.54.0:amd64
+libboost-thread1.54.0:amd64
+libnspr4:amd64
+libnss3:amd64
+libnss3-nssdb
+librados2
+librbd1
+qemu-utils

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -449,6 +449,7 @@ module Bosh::Stemcell
             :system_azure_network,
             :system_azure_wala,
             :system_parameters,
+            :bosh_azure_config_disk_packages,
             :enable_udf_module,
             :bosh_clean,
             :bosh_harden,

--- a/stemcell_builder/stages/bosh_azure_config_disk_packages/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_config_disk_packages/apply.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+
+packages="qemu-utils"
+pkg_mgr install $packages
+
+# we need to change the permission is because stemcell requires All Stemcells Library files must have mode 0755 or less permissiv
+run_in_chroot $chroot "
+  chmod 0700 /usr/lib/x86_64-linux-gnu/nss/*.chk
+"


### PR DESCRIPTION
because we need config disk support for azure cpi.
and we need the qemu-utils to create a vhd.