### PR TITLE
Make bosh-agent CPU priority higher than BOSH jobs

### DIFF
--- a/stemcell_builder/stages/bosh_go_agent/assets/runit/agent/run
+++ b/stemcell_builder/stages/bosh_go_agent/assets/runit/agent/run
@@ -6,4 +6,4 @@ exec 2>&1
 
 cd /var/vcap/bosh
 
-exec nice -n -10 /var/vcap/bosh/bin/bosh-agent -P $(cat /var/vcap/bosh/etc/operating_system) -C /var/vcap/bosh/agent.json
+exec nice -n -15 /var/vcap/bosh/bin/bosh-agent -P $(cat /var/vcap/bosh/etc/operating_system) -C /var/vcap/bosh/agent.json


### PR DESCRIPTION
We want the bosh-agent to continue communicating with the BOSH Director,
even then the instance is genuinely CPU-contended.

If the bosh-agent has the same CPU priority as all BOSH jobs,
when the instance is under extended CPU pressure,
it has been observed for the HM to re-create the host due to the
bosh-agent stopping communication with the Director.
This is bad, because the CPU is genuinely contended, and
re-creating the instance makes matters worse,
especially for distributed stateful systems such as RabbitMQ.

This was first reported as
https://github.com/cloudfoundry/bosh/issues/1949
and acknowledged by @cppforlife.