### PR TITLE
Make waagent depend on sshd.service

### DIFF
--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -43,7 +43,7 @@ if [ ${DISTRIB_CODENAME} == 'trusty' ]; then
   "
 else
   cp -f $dir/assets/etc/walinuxagent.service $chroot/lib/systemd/system/walinuxagent.service
-  chmod 0755 $chroot/lib/systemd/system/walinuxagent.service
+  chmod 0644 $chroot/lib/systemd/system/walinuxagent.service
   run_in_chroot $chroot "systemctl enable walinuxagent.service"
 fi
 

--- a/stemcell_builder/stages/system_azure_wala/assets/etc/walinuxagent.service
+++ b/stemcell_builder/stages/system_azure_wala/assets/etc/walinuxagent.service
@@ -9,7 +9,7 @@ Description=Azure Linux Agent
 
 After=network-online.target
 Wants=network-online.target
-
+Before=sshd.service
 ConditionFileIsExecutable=/usr/sbin/waagent
 ConditionPathExists=/etc/waagent.conf
 


### PR DESCRIPTION
our WAAgent depends on the ssh host key,
so we need waagent wait for the sshd running to indicate the ssh host key generated succesfully.
so it's important to add
Before= to the waagent.service.