### PR TITLE
Don't duplicate log entries and remove unneeded log files

### DIFF
--- a/stemcell_builder/stages/rsyslog_config/apply.sh
+++ b/stemcell_builder/stages/rsyslog_config/apply.sh
@@ -70,6 +70,7 @@ then
   fi
 elif [ -f $chroot/etc/redhat-release ] # Centos or RHEL
 then
+  sed -i "s@-/var/log/syslog@-/var/log/messages@g" $chroot/etc/rsyslog.d/50-default.conf
   mkdir -p $chroot/etc/systemd/system/var-log.mount.d/
   cp -f $assets_dir/start_rsyslog_on_mount.conf $chroot/etc/systemd/system/var-log.mount.d/start_rsyslog_on_mount.conf
   mkdir -p $chroot/etc/systemd/system/syslog.socket.d/

--- a/stemcell_builder/stages/rsyslog_config/assets/rsyslog_50-default.conf
+++ b/stemcell_builder/stages/rsyslog_config/assets/rsyslog_50-default.conf
@@ -10,35 +10,35 @@ auth,authpriv.*			/var/log/auth.log
 #cron.*				/var/log/cron.log
 daemon.*			-/var/log/daemon.log
 kern.*				-/var/log/kern.log
-lpr.*				-/var/log/lpr.log
-mail.*				-/var/log/mail.log
-user.*				-/var/log/user.log
+#lpr.*				-/var/log/lpr.log
+#mail.*				-/var/log/mail.log
+#user.*				-/var/log/user.log
 
 #
 # Logging for the mail system.  Split it up so that
 # it is easy to write scripts to parse these files.
 #
-mail.info			-/var/log/mail.info
-mail.warn			-/var/log/mail.warn
-mail.err			/var/log/mail.err
+#mail.info			-/var/log/mail.info
+#mail.warn			-/var/log/mail.warn
+#mail.err			/var/log/mail.err
 
 #
 # Logging for INN news system.
 #
-news.crit			/var/log/news/news.crit
-news.err			/var/log/news/news.err
-news.notice			-/var/log/news/news.notice
+#news.crit			/var/log/news/news.crit
+#news.err			/var/log/news/news.err
+#news.notice		-/var/log/news/news.notice
 
 #
 # Some "catch-all" log files.
 #
-*.=debug;\
-	auth,authpriv.none;\
-	news.none;mail.none	-/var/log/debug
-*.=info;*.=notice;*.=warn;\
-	auth,authpriv.none;\
-	cron,daemon.none;\
-	mail,news.none		-/var/log/messages
+#*.=debug;\
+#	auth,authpriv.none;\
+#	news.none;mail.none	-/var/log/debug
+#*.=info;*.=notice;*.=warn;\
+#	auth,authpriv.none;\
+#	cron,daemon.none;\
+#	mail,news.none		-/var/log/messages
 
 #
 # Emergencies are sent to everybody logged in.


### PR DESCRIPTION
- as default log file use /var/log/syslog on Ubuntu and
  /var/log/messages on CentOS
- don't write debug, lpr.log, mail.*, user.log and news.* files.
  They are already written into the default log file. These
  log entries are unimportant and we don't need extra files for them.

[#161684006](https://www.pivotaltracker.com/story/show/161684006)

Co-authored-by: Kai Hofstetter <kai.hofstetter@sap.com>