### PR TITLE
Configure chrony to use hardware clock on Azure

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -202,6 +202,7 @@ module Bosh::Stemcell
         :system_azure_wala,
         :system_parameters,
         :enable_udf_module,
+        :bosh_azure_chrony,
         :bosh_clean,
         :bosh_harden,
         :bosh_azure_agent_settings,

--- a/stemcell_builder/stages/bosh_azure_chrony/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_chrony/apply.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/lib/prelude_bosh.bash
+
+if [ ${DISTRIB_CODENAME} == 'xenial' ]; then
+  cp $dir/assets/chrony-updater-azure $chroot/$bosh_dir/bin/sync-time
+  chmod 0755 $chroot/$bosh_dir/bin/sync-time
+fi
+

--- a/stemcell_builder/stages/bosh_azure_chrony/assets/chrony-updater-azure
+++ b/stemcell_builder/stages/bosh_azure_chrony/assets/chrony-updater-azure
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+BOSH=/var/vcap/bosh
+
+exec > $BOSH/log/sync-time.out
+exec 2>&1
+
+new_file=/etc/chrony/chrony.conf.new
+cp /etc/chrony/chrony.conf.base $new_file
+
+echo "# appended by $0" >> $new_file
+
+echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> $new_file
+
+mv $new_file /etc/chrony/chrony.conf
+
+systemctl restart chrony.service
+chronyc waitsync 10


### PR DESCRIPTION
* On azure stemcells the sync-time script will be overwritten
* The chrony-updater-azure will configure chrony to use /dev/ptp0 as
hardware clock as described [in azure docs](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony)
* This prevents the need to configure UDP forwarding rules (necessary for NTP) in the Azure loadbalancer

Co-authored-by: David Ansari <david.ansari@sap.com>