### PR TITLE
Upgrade walinux agent to 2.2.36

### DIFF
--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -8,8 +8,8 @@ source $base_dir/lib/prelude_apply.bash
 packages="python python-pyasn1 python-setuptools"
 pkg_mgr install $packages
 
-wala_release=2.2.32
-wala_expected_sha1=3b5c6eac24e6545e3ce56262210a7ac8dbdc8ace
+wala_release=2.2.36
+wala_expected_sha1=9ff7fdb01f06f1f021669c3c4d024e172246eeb9
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')


### PR DESCRIPTION
Microsoft and Pivotal field folks have discovered that some of the early
2.2.3x builds are imcompatible with azure stack, and requested we
upgrade to 2.2.35 or higher. Stevenson has validated
that the agent fails running on stack only on Xenial 170+, when we
upgraded the version of walinux agent.

Signed-off-by: David Stevenson <dstevenson@pivotal.io>