### PR TITLE
Walinux rollback 2.2.25 for xenial 170

### DIFF
--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -8,8 +8,8 @@ source $base_dir/lib/prelude_apply.bash
 packages="python python-pyasn1 python-setuptools"
 pkg_mgr install $packages
 
-wala_release=2.2.36
-wala_expected_sha1=9ff7fdb01f06f1f021669c3c4d024e172246eeb9
+wala_release=2.2.32
+wala_expected_sha1=3b5c6eac24e6545e3ce56262210a7ac8dbdc8ace
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')

--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -8,8 +8,8 @@ source $base_dir/lib/prelude_apply.bash
 packages="python python-pyasn1 python-setuptools"
 pkg_mgr install $packages
 
-wala_release=2.2.32
-wala_expected_sha1=3b5c6eac24e6545e3ce56262210a7ac8dbdc8ace
+wala_release=2.2.25
+wala_expected_sha1=8fb9ef0558c11b70b48188fb5afd53eadc321fac
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')


### PR DESCRIPTION
Some mistakes were made when I asked you folks to upgrade to the latest walinux. We thought that would work with Azure Stack, because MS said they knew what the issue was, but it had the same problem as before. Since then I've built the stemcell locally and tried a lot of permutations of azure linux agent configurations. The only way I could get VMs to provision correctly was to rollback to the version of walinux we used in pre-170 xenial stemcells.