### PR TITLE
Allow logging with non-root users on xenial

### DIFF
--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
@@ -256,6 +256,17 @@ var _ = Describe("Stemcell", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exitStatus).To(Equal(0))
 		})
+
+		It("can write log messages to the system log file", func() {
+			_, _, exitStatus, err := bosh.Run(
+				"--column=stdout",
+				"ssh", "default/0", "-r", "-c",
+				`sudo adduser --disabled-password --gecos "" --quiet testuser && sudo -u testuser logger syslog-line && sudo userdel testuser`,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exitStatus).To(Equal(0))
+		})
 	})
 
 })

--- a/stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-rc
+++ b/stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-rc
@@ -7,11 +7,6 @@ if [ -e /dev/sr0 ]; then
   chown root:root /dev/sr0
 fi
 
-if [ -e /dev/log ]; then
-  chmod 0660 /dev/log
-  chown root:vcap /dev/log
-fi
-
 if [ -e /dev/shm ]; then
   chmod 0770 /dev/shm
   chown root:vcap /dev/shm


### PR DESCRIPTION
This change lifts restrictions on the socket file `/dev/log`, which
enables non-root users to log to syslog. This is currently also the
default on basic Ubuntu Xenial OS images.

[fixes #164427238](https://www.pivotaltracker.com/story/show/164427238)

Co-authored-by: Manuel Dewald <m.dewald@sap.com>