### PR TITLE
Set SSH ClientAliveInterval to 900

### DIFF
--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -38,9 +38,6 @@ echo 'Banner /etc/issue.net' >> $chroot/etc/ssh/sshd_config
 sed "/^ *IgnoreRhosts/d" -i $chroot/etc/ssh/sshd_config
 echo 'IgnoreRhosts yes' >> $chroot/etc/ssh/sshd_config
 
-sed "/^ *ClientAliveInterval/d" -i $chroot/etc/ssh/sshd_config
-echo 'ClientAliveInterval 900' >> $chroot/etc/ssh/sshd_config
-
 sed "/^ *PermitUserEnvironment/d" -i $chroot/etc/ssh/sshd_config
 echo 'PermitUserEnvironment no' >> $chroot/etc/ssh/sshd_config
 

--- a/stemcell_builder/stages/system_azure_wala/assets/etc/waagent.conf
+++ b/stemcell_builder/stages/system_azure_wala/assets/etc/waagent.conf
@@ -74,6 +74,9 @@ OS.RootDeviceScsiTimeout=300
 # If "None", the system default version is used.
 OS.OpensslPath=None
 
+# Set /etc/ssh/sshd_config ClientAliveInterval to 900
+OS.SshClientAliveInterval=900
+
 # If set, agent will use proxy server to access internet
 #HttpProxy.Host=None
 #HttpProxy.Port=None


### PR DESCRIPTION
The WALinuxAgent takes in the ClientAliveInterval as a property in its conf, and will default to
180 if none is set in the .conf file (see [here](https://github.com/Azure/WALinuxAgent/blob/v2.2.25/azurelinuxagent/common/conf.py#L195-L196) for the where it defaults to 180, and [here](https://github.com/Azure/WALinuxAgent/blob/v2.2.25/azurelinuxagent/common/osutil/default.py#L500-L510) for where this line is called). We intend it to be at 900 but the value we put in the sshd_config is being overwritten by the WALinuxAgent with the default 180. 