### PR TITLE
fix smoke test bug when disabling ipv6

### DIFF
--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Stemcell", func() {
 		stdOut, _, exitStatus, err := bosh.Run("--column=stdout", "ssh", "default/0", "-r", "-c", `sudo netstat -lnp | grep sshd | awk '{ print $4 }'`)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exitStatus).To(Equal(0))
-		Expect(strings.Split(strings.TrimSpace(stdOut), "\n")).To(Equal([]string{"0.0.0.0:22"}))
+		Expect(strings.Split(strings.TrimSpace(stdOut), "\n")).To(Equal([]string{"0.0.0.0:22\t", ":::22"}))
 	})
 
 	It("#140456537: enables sysstat", func() {


### PR DESCRIPTION
When I running bats test based on alibaba cloud, it always throw an error:
```
[Cmd Runner] 2019/03/30 09:26:00 DEBUG - Running command '/usr/local/bin/bosh -n -d stemcell-acceptance-tests --column=stdout ssh default/0 -r -c sudo netstat -lnp | grep sshd | awk '{ print $4 }''
[Cmd Runner] 2019/03/30 09:26:14 DEBUG - Stdout: 0.0.0.0:22    
:::22    
    
[Cmd Runner] 2019/03/30 09:26:14 DEBUG - Stderr: 
[Cmd Runner] 2019/03/30 09:26:14 DEBUG - Successful: true (0)
• Failure [13.917 seconds]
Stemcell [It] #141987897: disables ipv6 in the kernel 
/tmp/build/82c27cda/bosh-linux-stemcell-builder/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go:88

  Expected
      <[]string | len:2, cap:2>: ["0.0.0.0:22\t", ":::22"]
  to equal
      <[]string | len:1, cap:1>: ["0.0.0.0:22"]

  /tmp/build/82c27cda/bosh-linux-stemcell-builder/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go:92
```
I asked bosh channel for help, but the issue still exist, see [bosh Thread](https://cloudfoundry.slack.com/archives/C02HPPYQ2/p1552922833206100). After I modify the  `ipv4director/smoke/smoke_test.go`, the bats test can pass.