### PR TITLE
[#165802999] Add missing CIS/STIG audit rules and update auditd.conf

### DIFF
--- a/bosh-stemcell/spec/stemcells/cis_spec.rb
+++ b/bosh-stemcell/spec/stemcells/cis_spec.rb
@@ -19,8 +19,8 @@ describe 'CIS test case verification', {stemcell_image: true, security_spec: tru
         CIS-8.1.3
         CIS-8.1.4
         CIS-8.1.5
-        CIS-8.1.6
-        CIS-8.1.7
+        CIS-4.1.6
+        CIS-4.1.7
         CIS-8.1.8
         CIS-8.1.9
         CIS-8.1.10

--- a/bosh-stemcell/spec/stemcells/stig_spec.rb
+++ b/bosh-stemcell/spec/stemcells/stig_spec.rb
@@ -106,7 +106,7 @@ describe 'Stig test case verification', stemcell_image: true, security_spec: tru
       V-38631
       V-38632
       V-38633
-      V-38634
+      V-75627
       V-38636
       V-38637
       V-38638

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -572,8 +572,9 @@ shared_examples_for 'every OS image' do
         its (:content) { should match /^max_log_file = 6$/ }
       end
 
-      describe 'rotating the logs so the disk does not run out of space (stig: V-38634)' do
-        its (:content) { should match /^max_log_file_action = ROTATE$/ }
+      describe 'the System Administrator (SA) and Information System Security Officer (ISSO) (at a minimum)
+must be alerted when the audit storage volume is full. (stig: V-75627)' do
+        its (:content) { should match /^max_log_file_action = SYSLOG$/ }
       end
 
       describe 'keeping the logs around for a sensible retention period (stig: V-38636)' do
@@ -630,6 +631,7 @@ shared_examples_for 'every OS image' do
 
     describe 'record changes to sudoers file (CIS-8.1.15)' do
       its(:content) { should match /^-w \/etc\/sudoers -p wa -k scope$/ }
+      its(:content) { should match /^-w \/etc\/sudoers\.d -p wa -k scope$/ }
     end
 
     describe 'record login and logout events (CIS-8.1.8)' do
@@ -653,17 +655,19 @@ shared_examples_for 'every OS image' do
       its(:content) { should match /^-w \/etc\/security\/opasswd -p wa -k identity$/ }
     end
 
-    describe 'record events that modify system network environment (CIS-8.1.6)' do
+    describe 'record events that modify system network environment (CIS-4.1.6)' do
       its(:content) { should match /^-a exit,always -F arch=b64 -S sethostname -S setdomainname -k system-locale$/ }
       its(:content) { should match /^-a exit,always -F arch=b32 -S sethostname -S setdomainname -k system-locale$/ }
       its(:content) { should match /^-w \/etc\/issue -p wa -k system-locale$/ }
       its(:content) { should match /^-w \/etc\/issue\.net -p wa -k system-locale$/ }
       its(:content) { should match /^-w \/etc\/hosts -p wa -k system-locale$/ }
       its(:content) { should match /^-w \/etc\/network -p wa -k system-locale$/ }
+      its(:content) { should match /^-w \/etc\/networks -p wa -k system-locale$/ }
     end
 
-    describe 'record events that modify systems mandatory access controls (CIS-8.1.7)' do
-      its(:content) { should match /^-w \/etc\/selinux\/ -p wa -k MAC-policy$/ }
+    describe 'record events that modify systems mandatory access controls (CIS-4.1.7)' do
+      its(:content) { should match /^-w \/etc\/apparmor\/ -p wa -k MAC-policy$/ }
+      its(:content) { should match /^-w \/etc\/apparmor\.d\/ -p wa -k MAC-policy$/ }
     end
 
     describe 'record system administrator actions (CIS-8.1.16)' do

--- a/stemcell_builder/stages/bosh_audit/shared_functions.bash
+++ b/stemcell_builder/stages/bosh_audit/shared_functions.bash
@@ -31,6 +31,7 @@ function write_shared_audit_rules {
 
 # Record changes to sudoers file
 -w /etc/sudoers -p wa -k scope
+-w /etc/sudoers.d -p wa -k scope
 
 # Record login and logout events
 -w /var/log/faillog -p wa -k logins
@@ -57,9 +58,11 @@ function write_shared_audit_rules {
 -w /etc/issue.net -p wa -k system-locale
 -w /etc/hosts -p wa -k system-locale
 -w /etc/network -p wa -k system-locale
+-w /etc/networks -p wa -k system-locale
 
 # Record events that modify systems mandatory access controls
--w /etc/selinux/ -p wa -k MAC-policy
+-w /etc/apparmor/ -p wa -k MAC-policy
+-w /etc/apparmor.d/ -p wa -k MAC-policy
 
 # Record system administrator actions
 -w /var/log/sudo.log -p wa -k actions
@@ -118,7 +121,7 @@ function override_default_audit_variables {
     sed -i 's/^space_left_action = .*$/space_left_action = SYSLOG/g' $chroot/etc/audit/auditd.conf
     sed -i 's/^num_logs = .*$/num_logs = 5/g' $chroot/etc/audit/auditd.conf
     sed -i 's/^max_log_file = .*$/max_log_file = 6/g' $chroot/etc/audit/auditd.conf
-    sed -i 's/^max_log_file_action = .*$/max_log_file_action = ROTATE/g' $chroot/etc/audit/auditd.conf
+    sed -i 's/^max_log_file_action = .*$/max_log_file_action = SYSLOG/g' $chroot/etc/audit/auditd.conf
     sed -i 's/^log_group = .*$/log_group = root/g' $chroot/etc/audit/auditd.conf
     sed -i 's/^space_left = .*$/space_left = 75/g' $chroot/etc/audit/auditd.conf
     sed -i 's/^admin_space_left = .*$/admin_space_left = 50/g' $chroot/etc/audit/auditd.conf


### PR DESCRIPTION
# CIS

**4.1.6 Ensure events that modify the system's network environment are collected**
- Added 

  ```-w /etc/networks -p wa -k system-locale``` 

  in 

  ```/etc/audit/rules.d/audit.rules```

**4.1.7 Ensure events that modify the system's Mandatory Access Controls are collected (Scored)**
- Updated 

     ```-w /etc/selinux/ -p wa -k MAC-policy```

      to 
     
     
     ```-w /etc/apparmor/ -p wa -k MAC-policy```

     ```-w /etc/apparmor.d/ -p wa -k MAC-policy```
     
      in
      
    ```/etc/audit/rules.d/audit.rules```

    Stemcell does not use SELinux for MAC


# STIG
**V-75627 The System Administrator (SA) and Information System Security Officer (ISSO) (at a minimum) must be alerted when the audit storage volume is full.**
- Updated 

   ```max_log_file_action = ROTATE```

    to 
    
   ```max_log_file_action = SYSLOG```

    in 
    
    ```/etc/audit/auditd.conf```
