### PR TITLE
blacklist nouveau kernel module

### DIFF
--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -21,6 +21,13 @@ install udf /bin/true
 install rds /bin/true
 options ipv6 disable=1' >> $chroot/etc/modprobe.d/blacklist.conf
 
+echo '# prevent nouveau from loading
+blacklist nouveau
+blacklist lbm-nouveau
+options nouveau modeset=0
+alias nouveau off
+alias lbm-nouveau off' >> $chroot/etc/modprobe.d/blacklist-nouveau.conf
+
 if [[ $OS_TYPE == 'ubuntu' ]]; then
   rm -rf $chroot/lib/modules/*/kernel/zfs $chroot/usr/src/linux-headers-*/zfs
 fi


### PR DESCRIPTION
Commit creates a `/etc/modprobe.d/blacklist-nouveau.conf` file that contains the modules required to disable the open source nouveau module.

`nouveau` module is useful to provide Open source support for nvidia GPUs and hardware acceleration for 3d rendering on desktops. On server side, users typically require the proprietary `nvidia` module which supports CUDA workloads for utilizing GPUs for compute capabilities. [Nvidia documentation](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#pre-installation-actions) provides this as a pre-requisite, along with the [thread](https://askubuntu.com/questions/841876/how-to-disable-nouveau-kernel-driver) from Ubuntu community. Swapping the kernel module from  `nouveau` to `nvidia` during runtime didn't seem possible as the BOSH resurrector replaced the VM based on my testing on Azure, when I forced removed the `nouveau` module on a running VM Instance.

I've tested AWS and Azure stemcell builds and I was able to use the stemcell image to build a PKS cluster with nvidia GPU attached workers and Tensorflow based workload using GPUs from Kubernetes.

This PR should address issue #90 .