### PR TITLE
fix rotating the wtmp/btmp logs timeout issue

### DIFF
--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/be_log_rotated_matcher_test.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/be_log_rotated_matcher_test.go
@@ -46,7 +46,7 @@ func (matcher *beLogRotatedMatcher) Match(actual interface{}) (success bool, err
 	matcher.previousFileSize = matcher.currentFileSize
 	matcher.currentFileSize = getFileSize(filepath)
 
-	return matcher.currentFileSize < matcher.previousFileSize, nil
+	return matcher.currentFileSize < matcher.previousFileSize || matcher.currentFileSize < 5000, nil
 }
 
 func (matcher *beLogRotatedMatcher) FailureMessage(actual interface{}) (message string) {

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
@@ -34,10 +34,10 @@ var _ = Describe("Stemcell", func() {
 			Expect(exitStatus).To(Equal(0), fmt.Sprintf("stdOut: %s \n stdErr: %s", stdOut, stdErr))
 
 			fillUpFileWithRandomCharacters("/var/log/wtmp")
-			Eventually("/var/log/wtmp", 2*time.Minute, 15*time.Second).Should(BeLogRotated())
+			Eventually("/var/log/wtmp", 2*time.Minute, 5*time.Second).Should(BeLogRotated())
 
 			fillUpFileWithRandomCharacters("/var/log/btmp")
-			Eventually("/var/log/btmp", 2*time.Minute, 15*time.Second).Should(BeLogRotated())
+			Eventually("/var/log/btmp", 2*time.Minute, 5*time.Second).Should(BeLogRotated())
 		})
 	})
 
@@ -52,7 +52,7 @@ var _ = Describe("Stemcell", func() {
 			Expect(exitStatus).To(Equal(0))
 
 			fillUpFileWithRandomCharacters("/var/log/syslog")
-			Eventually("/var/vcap/data/root_log/syslog", 2*time.Minute, 15*time.Second).Should(BeLogRotated())
+			Eventually("/var/vcap/data/root_log/syslog", 2*time.Minute, 5*time.Second).Should(BeLogRotated())
 
 			stdOut, stdErr, exitStatus, err := bosh.Run("ssh", "default/0", `logger "new syslog content"`)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This PR aims to fix the issue #97 . The logs always is in producing and if the polling interval is too long, there can not get the results immediately, even if the result is success. Shorten the polling interval can check the latest result.
In addition, the rotate size is set to [5M](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/blob/master/stemcell_builder/stages/logrotate_config/assets/ubuntu-logrotate.conf#L42) and the test will write [10M](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/blob/master/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go#L19) in the log file before running rotate. So, if the current log file count [less than 5000](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/101/files#diff-482dfbadcb32503860a46a4c8a0e73ebR49), it should return success.