### PR TITLE
Upgrade walinux agent to latest

### DIFF
--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -8,8 +8,8 @@ source $base_dir/lib/prelude_apply.bash
 packages="python python-pyasn1 python-setuptools"
 pkg_mgr install $packages
 
-wala_release=2.2.44
-wala_expected_sha1=9a89854ea89e8a7f6de8ca84493b8df3526e0bc0
+wala_release=2.2.45
+wala_expected_sha1=571089321230d7bad681bd8fcc5d861ecfbc4815
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')

--- a/stemcell_builder/stages/system_azure_wala/apply.sh
+++ b/stemcell_builder/stages/system_azure_wala/apply.sh
@@ -8,8 +8,8 @@ source $base_dir/lib/prelude_apply.bash
 packages="python python-pyasn1 python-setuptools"
 pkg_mgr install $packages
 
-wala_release=2.2.25
-wala_expected_sha1=8fb9ef0558c11b70b48188fb5afd53eadc321fac
+wala_release=2.2.44
+wala_expected_sha1=9a89854ea89e8a7f6de8ca84493b8df3526e0bc0
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')

--- a/stemcell_builder/stages/system_azure_wala/assets/etc/waagent.conf
+++ b/stemcell_builder/stages/system_azure_wala/assets/etc/waagent.conf
@@ -1,23 +1,20 @@
 #
 # Windows Azure Linux Agent Configuration
-#
-
-# Specified program is invoked with the argument "Ready" when we report ready status
-# to the endpoint server.
-Role.StateConsumer=None
-
-# Specified program is invoked with XML file argument specifying role
-#  configuration.
-Role.ConfigurationConsumer=None
-
-# Specified program is invoked with XML file argument specifying role topology.
-Role.TopologyConsumer=None
+#   Configuration that differs from default ubuntu config
+#   is labled with "NON-DEFAULT".
 
 # Enable instance creation
 Provisioning.Enabled=y
 
+# Enable extension handling. Do not disable this unless you do not need password reset,
+# backup, monitoring, or any extension handling whatsoever.
+Extensions.Enabled=y
+
+# Rely on cloud-init to provision
+Provisioning.UseCloudInit=n  # NON-DEFAULT, the BOSH agent takes this place
+
 # Password authentication for root account will be unavailable.
-Provisioning.DeleteRootPassword=n
+Provisioning.DeleteRootPassword=n  # NON-DEFAULT, already in stemcell
 
 # Generate fresh host key pair.
 Provisioning.RegenerateSshHostKeyPair=n
@@ -29,10 +26,19 @@ Provisioning.SshHostKeyPairType=rsa
 Provisioning.MonitorHostName=n
 
 # Decode CustomData from Base64.
-Provisioning.DecodeCustomData=y
+Provisioning.DecodeCustomData=y  # NON-DEFAULT, needed by BOSH agent to get metadata
 
 # Execute CustomData after provisioning.
 Provisioning.ExecuteCustomData=n
+
+# Algorithm used by crypt when generating password hash.
+#Provisioning.PasswordCryptId=6
+
+# Length of random salt used when generating password hash.
+#Provisioning.PasswordCryptSaltLength=10
+
+# Allow reset password of sys user
+Provisioning.AllowResetSysUser=n
 
 # Format if unformatted. If 'n', resource disk will not be mounted.
 ResourceDisk.Format=n
@@ -42,13 +48,16 @@ ResourceDisk.Format=n
 ResourceDisk.Filesystem=ext4
 
 # Mount point for the resource disk
-ResourceDisk.MountPoint=/mnt/resource
+ResourceDisk.MountPoint=/mnt/resource  # NON-DEFAULT, but not mounted
 
 # Create and use swapfile on resource disk.
 ResourceDisk.EnableSwap=n
 
 # Size of the swapfile.
 ResourceDisk.SwapSizeMB=0
+
+# Comma-seperated list of mount options. See man(8) for valid options.
+ResourceDisk.MountOptions=None
 
 # Respond to load balancer probes if requested by Windows Azure.
 LBProbeResponder=y
@@ -60,13 +69,13 @@ Logs.File=/var/log/waagent.log
 # Enable logging to serial console (y|n)
 # When stdout is not enough...
 # 'y' if not set
-Logs.Console=y
+Logs.Console=y  # NON-DEFAULT, helps get debugging output if we can't SSH in
 
 # Enable verbose logging (y|n)
 Logs.Verbose=n
 
-# Preferred network interface to communicate with Azure platform
-#Network.Interface=eth0
+# Is FIPS enabled
+OS.EnableFIPS=n
 
 # Root device timeout in seconds.
 OS.RootDeviceScsiTimeout=300
@@ -75,11 +84,44 @@ OS.RootDeviceScsiTimeout=300
 OS.OpensslPath=None
 
 # Set /etc/ssh/sshd_config ClientAliveInterval to 900
-OS.SshClientAliveInterval=900
+OS.SshClientAliveInterval=900 # NON-DEFAULT, works around azure TCP NAT tables timeouts
 
 # If set, agent will use proxy server to access internet
 #HttpProxy.Host=None
 #HttpProxy.Port=None
 
-# Disable goal state processing auto-update, we should make the stemcell stable enough.
-AutoUpdate.Enabled=n
+# Detect Scvmm environment, default is n
+# DetectScvmmEnv=n
+
+# Enable RDMA management and set up, should only be used in HPC images
+# OS.EnableRDMA=y
+
+# Enable RDMA kernel update, this value is effective on Ubuntu
+# OS.UpdateRdmaDriver=y
+
+# Enable checking RDMA driver version and update
+# OS.CheckRdmaDriver=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+AutoUpdate.Enabled=n # NON-DEFAULT, we want to hold the version of the walinux agent
+
+# Determine the update family, this should not be changed
+# AutoUpdate.GAFamily=Prod
+
+# Determine if the overprovisioning feature is enabled. If yes, hold extension
+# handling until inVMArtifactsProfile.OnHold is false.
+# Default is enabled
+# EnableOverProvisioning=y
+
+# Allow fallback to HTTP if HTTPS is unavailable
+# Note: Allowing HTTP (vs. HTTPS) may cause security risks
+# OS.AllowHTTP=n
+
+# Add firewall rules to protect access to Azure host node services
+OS.EnableFirewall=n  # NON-DEFAULT
+
+# Enforce control groups limits on the agent and extensions
+CGroups.EnforceLimits=n
+
+# CGroups which are excluded from limits, comma separated
+CGroups.Excluded=customscript,runcommand


### PR DESCRIPTION
Customer has seen a low overflow bug happen on a few diego cells, where the agent will uncontrollably spew logs.
Side issue: logs aren't getting rotated due to overmount of /var/log, but that's a separate problem.
We're likely overdue for an upgrade anyway.

Signed-off-by: David Stevenson <dstevenson@pivotal.io>