### PR TITLE
[#168964744] make rsyslog and logrotate configs consistent

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -142,11 +142,6 @@ shared_examples_for 'every OS image' do
         expect(subject.content).not_to match 'restart rsyslog'
       end
 
-      it 'should configure the news services' do
-        expect(subject.content).to match '/var/log/news/news.crit'
-        expect(subject.content).to match '/var/log/news/news.err'
-        expect(subject.content).to match '/var/log/news/news.notice'
-      end
     end
   end
 

--- a/stemcell_builder/stages/rsyslog_config/apply.sh
+++ b/stemcell_builder/stages/rsyslog_config/apply.sh
@@ -37,14 +37,7 @@ run_in_bosh_chroot $chroot "
 "
 
 # Configure /var/log directory
-filenames=( auth.log cloud-init.log daemon.log debug kern.log lpr.log mail.err mail.info \
-              mail.log mail.warn messages news/news.crit news/news.err \
-              news/news.notice syslog user.log cron.log )
-
-
-run_in_bosh_chroot $chroot "
-  mkdir -p /var/log/news
-"
+filenames=( auth.log cloud-init.log daemon.log kern.log syslog cron.log )
 
 for filename in ${filenames[@]}
 do

--- a/stemcell_builder/stages/rsyslog_config/assets/rsyslog_logrotate.conf
+++ b/stemcell_builder/stages/rsyslog_config/assets/rsyslog_logrotate.conf
@@ -16,21 +16,10 @@
 	endscript
 }
 
-/var/log/mail.info
-/var/log/mail.warn
-/var/log/mail.err
-/var/log/mail.log
 /var/log/daemon.log
 /var/log/kern.log
 /var/log/auth.log
-/var/log/user.log
-/var/log/lpr.log
 /var/log/cron.log
-/var/log/debug
-/var/log/messages
-/var/log/news/news.crit
-/var/log/news/news.err
-/var/log/news/news.notice
 {
 	su syslog syslog
 	rotate 4


### PR DESCRIPTION
https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/75 removed duplicate/unneeded log file entries from `rsyslog_50-default.conf`, but these logs are still configured to be log-rotated.
This causes CIS level 1 Rule 4.3 to fail