### PR TITLE
Fix local stemcell build using Docker on macOS

### DIFF
--- a/ci/docker/os-image-stemcell-builder/Dockerfile
+++ b/ci/docker/os-image-stemcell-builder/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH /opt/rubies/ruby-2.6.3/bin:/opt/rubies/ruby-2.4.5/bin:$PATH
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
-RUN groupadd -g ${GROUP_ID} ubuntu                  \
+RUN groupadd -o -g ${GROUP_ID} ubuntu                  \
   && useradd -u ${USER_ID} -g ${GROUP_ID} -m ubuntu \
   && echo 'ubuntu ALL=NOPASSWD:ALL' >> /etc/sudoers \
   && echo 'root ALL=(ALL:ALL) ALL' >> /etc/sudoers


### PR DESCRIPTION
Currently, this project requires a Docker image from which we build a
stemcell.

A user is then created within this image and given privileges:

```shell
ARG USER_ID=1000
ARG GROUP_ID=1000

RUN groupadd -o -g ${GROUP_ID} ubuntu                  \
  && useradd -u ${USER_ID} -g ${GROUP_ID} -m ubuntu \
  && echo 'ubuntu ALL=NOPASSWD:ALL' >> /etc/sudoers \
  && echo 'root ALL=(ALL:ALL) ALL' >> /etc/sudoers
```

The `run` script tries to capture the current UID and GUID in order to
use it to create the user:

```shell
NEW_GID="$(id -g)"

docker build                      \
  --build-arg USER_ID="$NEW_UID"  \
  --build-arg GROUP_ID="$NEW_GID" \
  -t "$DOCKER_IMAGE"              \
  .

docker run --privileged \
  -v "$DIR/../..:/opt/bosh" \
  --workdir /opt/bosh \
  "--user=$NEW_UID:$NEW_GID" \
  -t -i "$DOCKER_IMAGE"
```

When executed on a macOS, the `id -g` command can return a group number
that is already in use in the container's image:

```
$ ./run os-image-stemcell-builder
Step 19/30 : RUN groupadd -g ${GROUP_ID} ubuntu                    && useradd -u ${USER_ID} -g ${GROUP_ID} -m ubuntu   && echo 'ubuntu ALL=NOPASSWD:ALL' >> /etc/sudoers   && echo 'root ALL=(ALL:ALL) ALL' >> /etc/sudoers
 ---> Running in c7563c2412e3
groupadd: GID '20' already exists
The command '/bin/sh -c groupadd -g ${GROUP_ID} ubuntu                    && useradd -u ${USER_ID} -g ${GROUP_ID} -m ubuntu   && echo 'ubuntu ALL=NOPASSWD:ALL' >> /etc/sudoers   && echo 'root ALL=(ALL:ALL) ALL' >> /etc/sudoers' returned a non-zero code: 4
```

I am proposing we allow group duplicates to work around this, as in:

```
ubuntu@98b2a2aed0e6:/opt/bosh$ groupadd -h
Usage: groupadd [options] GROUP

Options:
  -o, --non-unique              allow to create groups with duplicate
                                (non-unique) GID
```