### PR TITLE
Fix for recent change in base-files package

### DIFF
--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -92,5 +92,10 @@ for file in $chroot/etc/{issue,issue.net,motd}; do
     chmod 644 $file
 done
 
-# Disable Ubuntu motd
-sudo sed -i 's/^ENABLED=.*/ENABLED=0/' $chroot/etc/default/motd-news
+# Disable Ubuntu motd (and create file if missing)
+if [[ -e $chroot/etc/default/motd-news ]]
+then
+  sudo sed -i 's/^ENABLED=.*/ENABLED=0/' $chroot/etc/default/motd-news
+else
+  sudo echo "ENABLED=0" >$chroot/etc/default/motd-news
+fi


### PR DESCRIPTION
Changes in https://lists.ubuntu.com/archives/xenial-changes/2020-August/028036.html break one test in the build process.  This ensures the MOTD change is present

[#174637996](https://www.pivotaltracker.com/story/show/174637996)