### PR TITLE
use a wildcard for the linux-headers

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_bionic_spec.rb
@@ -68,7 +68,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
 
       it 'should be a proper superset of the installed static libraries' do
         libraries_to_remove = subject.content.split("\n")
-        found_libraries = command("find / -iname '*.a' | sort | uniq").stdout.split("\n")
+        found_libraries = command("find / -iname '*.a' | sort | uniq | sed -E 's/(linux.*5.4).*-generic/\1.*-generic/'" ).stdout.split("\n")
 
         expect(libraries_to_remove).to include(*found_libraries)
       end

--- a/stemcell_builder/stages/static_libraries_config/assets/bionic_static_libraries_list.txt
+++ b/stemcell_builder/stages/static_libraries_config/assets/bionic_static_libraries_list.txt
@@ -108,4 +108,4 @@
 /usr/lib/x86_64-linux-gnu/liby.a
 /usr/lib/x86_64-linux-gnu/libz.a
 /usr/lib64/libyaml.a
-/usr/src/linux-headers-5.4.0-48-generic/tools/objtool/libsubcmd.a
+/usr/src/linux-headers-5.4.*-generic/tools/objtool/libsubcmd.a


### PR DESCRIPTION
the bosh agent will executes 'rm -rf' for each line
when static libraries need to be removed