### PR TITLE
WIP: Fix IPv6 issue in grub configuration on alicloud

### DIFF
--- a/bosh-stemcell/spec/stemcells/alicloud_spec.rb
+++ b/bosh-stemcell/spec/stemcells/alicloud_spec.rb
@@ -24,4 +24,18 @@ describe 'AliCloud Stemcell', stemcell_image: true do
       its(:content) { should_not match /metadata_csum/ }
     end
   end
+
+  context 'default grub configuration' do
+    describe file('/etc/default/grub') do
+      it { should be_file }
+      its(:content) { should match '^GRUB_CMDLINE_LINUX_DEFAULT="ipv6.disable=1"' }
+    end
+  end
+
+  context 'installed by image_install_grub' do
+    describe file('/boot/grub/grub.cfg') do
+      it { should be_file }
+      its(:content) { should match ' ipv6.disable=1' }
+    end
+  end
 end

--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -75,6 +75,10 @@ run_in_chroot ${image_mount_point} "grub-install -v --no-floppy --grub-mkdevicem
 run_in_chroot ${image_mount_point} "sed -i 's/CLASS=\\\"--class gnu-linux --class gnu --class os\\\"/CLASS=\\\"--class gnu-linux --class gnu --class os --unrestricted\\\"/' /etc/grub.d/10_linux"
 
 grub_suffix=""
+if [ "${stemcell_infrastructure}" == "alicloud" ]; then
+  grub_suffix="\""$'\n'"GRUB_CMDLINE_LINUX_DEFAULT=\"ipv6.disable=1"
+fi
+
 if [ "${stemcell_infrastructure}" == "aws" ]; then
   grub_suffix="nvme_core.io_timeout=4294967295"
 fi


### PR DESCRIPTION
This PR is a workaround to fix the IPv6 issues on alicloud as described in https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/132.

**Problem:**
IPv6 is disabled `ipv6.disable=1` using the kernel boot parameters defined in the grub configuration `/etc/default/grub`. However on alicloud the kernel boot parameter `ipv6.disable=1` disappeared in files `/etc/default/grub` and `/boot/grub/grub.cfg` after a vm was created. Obviously _bosh-agent_ removed the parameter from configuration, but this is not the case as it only operate on file `/boot/grub/grub.cfg`. The logs are not showing any process which is manipulating the grub configuration on startup.
 
The file `/etc/default/grub`should never be changed on a vm, so we should expect:
```
GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 audit=1 ipv6.disable=1 cgroup_enable=memory swapaccount=1"
```
but we found:
```
GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 audit=1  cgroup_enable=memory swapaccount=1  console=tty0"
```

The root cause is still unknown.

**Workaround:**
For alicloud we add a new configuration item GRUB_CMDLINE_LINUX_DEFAULT to the grub configuration specifying again the kernel boot parameter `ipv6.disable=1`. This change will survive the boot process and IPv6 on alicloud is disabled. Enable IPv6 using the _bosh-agent_ works as expected (tested).
