### PR TITLE
Updating dracut configuration file to fix crc32c error message

### DIFF
--- a/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
@@ -34,6 +34,18 @@ describe 'Ubuntu 18.04 OS image', os_image: true do
     it { should be_enabled }
   end
 
+  context 'installed by system_kernel' do
+    describe package('linux-generic-hwe-18.04') do
+      it { should be_installed }
+    end
+  end
+
+  context 'installed by system_kernel' do
+    describe file('/etc/dracut.conf.d/10-debian.conf') do
+      its(:content) { should_not match '^add_drivers.*' }
+    end
+  end
+
   describe 'base_apt' do
     describe file('/etc/apt/sources.list') do
       its(:content) { should match 'deb http://archive.ubuntu.com/ubuntu bionic main universe multiverse' }

--- a/stemcell_builder/stages/system_kernel/apply.sh
+++ b/stemcell_builder/stages/system_kernel/apply.sh
@@ -11,6 +11,8 @@ mkdir -p $chroot/tmp
 
 
 if [[  "${DISTRIB_CODENAME}" == "bionic" ]]; then
+  # remove additional drivers like crc32c kernel module.
+  sed -i "/^add_drivers.*/d" $chroot/etc/dracut.conf.d/10-debian.conf
   pkg_mgr install linux-generic-hwe-18.04
 elif [[ "${DISTRIB_CODENAME}" == "xenial" ]]; then
   pkg_mgr install linux-generic-hwe-16.04


### PR DESCRIPTION
Dracut failed to find module `crc32c` during building the initramfs for a kernel with message

```
Processing triggers for linux-image-5.4.0-66-generic (5.4.0-66.74~18.04.2) ...
/etc/kernel/postinst.d/dracut:
dracut: Generating /boot/initrd.img-5.4.0-66-generic
dracut: Turning off host-only mode: '/sys' is not mounted!
dracut: Turning off host-only mode: '/run' is not mounted!
dracut-install: Failed to find module 'crc32c'
dracut: FAILED:  /usr/lib/dracut/dracut-install -D /var/tmp/dracut.yDMHVU/initramfs --kerneldir /lib/modules/5.4.0-66-generic/ -m crc32c
```

This PR will update the default dracut configuration file by removing the line starting with `add_drivers`. The kernel module `crcr32c` is loaded by default. In newer Ubuntu versions (like focal) the configuration property `add_drivers` is not configured anymore.
