### PR TITLE
Remove deprecated option --force-yes from apt-get command

### DIFF
--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -21,7 +21,7 @@ fi
 
 function pkg_mgr {
   run_in_chroot $chroot "apt-get update"
-  run_in_chroot $chroot "export DEBIAN_FRONTEND=noninteractive;apt-get -f -y --force-yes --no-install-recommends $*"
+  run_in_chroot $chroot "export DEBIAN_FRONTEND=noninteractive;apt-get -f -y --no-install-recommends $*"
   run_in_chroot $chroot "apt-get clean"
 }
 


### PR DESCRIPTION
The option `--force-yes` for `apt-get` command is deprecated so let's remove it.

I did not considered using one of the alternative options like `--allow-unauthenticated` , `--allow-downgrades` , `--allow-remove-essential` or `--allow-change-held-packages`. If something is broken we see it in the build pipeline.