### PR TITLE
Remove .gitmodules from bionic branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/github.com/cloudfoundry/bosh-agent"]
-	path = src/github.com/cloudfoundry/bosh-agent
-	url = https://github.com/cloudfoundry/bosh-agent.git


### PR DESCRIPTION
bosh-agent submodule was removed some time ago. See also commit https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/99550339a66fed36c08d0fd8db645c950a972a98