### PR TITLE
Force rsyslog to wait for /var/log to be mounted

### DIFF
--- a/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
@@ -336,6 +336,23 @@ EOF
     end
   end
 
+  describe 'rsyslog modifications' do
+    describe file('/etc/systemd/system/rsyslog.service') do
+      its(:content) { should include "ExecStartPre=/usr/local/bin/wait_for_var_log_to_be_mounted" }
+
+      it 'only differs by the ExecStartPre directive' do
+        content = subject.content.gsub("ExecStartPre=/usr/local/bin/wait_for_var_log_to_be_mounted\n", "")
+        original_service_content = file("/lib/systemd/system/rsyslog.service").content
+        expect(content).to eq(original_service_content)
+      end
+    end
+
+    describe file('/usr/local/bin/wait_for_var_log_to_be_mounted') do
+      it { should be_file }
+      its(:mode) { should eq(0o755) }
+    end
+  end
+
   describe 'allowed user accounts' do
     describe file('/etc/passwd') do
       its(:content) { should eql(<<HERE) }

--- a/stemcell_builder/stages/rsyslog_config/apply.sh
+++ b/stemcell_builder/stages/rsyslog_config/apply.sh
@@ -48,6 +48,12 @@ do
 done
 
 # init.d configuration is different for each OS
+mkdir -p $chroot/usr/local/bin
+cp -f $assets_dir/wait_for_var_log_to_be_mounted $chroot/usr/local/bin/wait_for_var_log_to_be_mounted
+chmod 755 $chroot/usr/local/bin/wait_for_var_log_to_be_mounted
+grep -q "ExecStart=" $chroot/lib/systemd/system/rsyslog.service || (echo "Unable to find ExecStart key in $chroot/lib/systemd/system/rsyslog.service"; exit 1)
+sed "s@ExecStart=@ExecStartPre=/usr/local/bin/wait_for_var_log_to_be_mounted\nExecStart=@g" $chroot/lib/systemd/system/rsyslog.service > $chroot/etc/systemd/system/rsyslog.service
+
 mkdir -p $chroot/etc/systemd/system/var-log.mount.d/
 cp -f $assets_dir/start_rsyslog_on_mount.conf $chroot/etc/systemd/system/var-log.mount.d/start_rsyslog_on_mount.conf
 mkdir -p $chroot/etc/systemd/system/syslog.socket.d/

--- a/stemcell_builder/stages/rsyslog_config/assets/wait_for_var_log_to_be_mounted
+++ b/stemcell_builder/stages/rsyslog_config/assets/wait_for_var_log_to_be_mounted
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+until mountpoint -q /var/log
+do
+    sleep .1
+done


### PR DESCRIPTION
Take-over from commit https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/35e684b1f1203e23af0aaed6961cd607f3508a97 for Xenial stemcell.