### PR TITLE
do not use /var/vcap/store in the ns for chrony as chrony is configured to use a Private namespace see #151

### DIFF
--- a/bosh-stemcell/spec/support/os_image_systemd_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_systemd_shared_examples.rb
@@ -15,6 +15,7 @@ shared_examples_for 'a systemd-based OS image' do
     describe file('/etc/systemd/system/chrony.service.d/restart.conf') do
       it { should be_file }
       its(:content) { should match /^Restart=always/ }
+      its(:content) { should match /^InaccessiblePaths=\/var\/vcap\/store/ }
     end
 
     describe file('/etc/systemd/system/var-log.mount.d/start_rsyslog_on_mount.conf') do

--- a/stemcell_builder/stages/bosh_ntp/assets/restart.conf
+++ b/stemcell_builder/stages/bosh_ntp/assets/restart.conf
@@ -4,4 +4,4 @@ PIDFile=/var/run/chronyd.pid
 RemainAfterExit=no
 Restart=always
 RestartSec=5s
-
+InaccessiblePaths=/var/vcap/store


### PR DESCRIPTION
this PR will fix #151 
chrony uses  the following systemd settings 
```
PrivateTmp=yes
ProtectHome=yes
ProtectSystem=full
```
this results in a private namespace.
when `/var/vcap/store` is mounted and chrony restart.
the namespace created will then retrieve all the current active mountpoints.

if bosh will recreate the vm and wants to detach the disk. it will get stuck as chrony's namespace is still using the mountpoint
and mount does not have access to the namespace.

this pr will prevent the use that the ns will never mount  `/var/vcap/store`
