### PR TITLE
Machine-id should be unique for each created vm

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -248,6 +248,7 @@ module Bosh::Stemcell
         :escape_ctrl_alt_del,
         :bosh_audit_ubuntu,
         :bosh_log_audit_start,
+        :clean_machine_id,
       ].flatten
     end
 

--- a/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
@@ -151,6 +151,17 @@ EOF
     end
   end
 
+  context 'created image should not contain machine id' do
+    describe file('/etc/machine-id') do
+      it { should be_file}
+      its(:content) { should match '' }
+    end
+
+    describe file('/var/lib/dbus/machine-id') do
+      it { should_not be_file }
+    end
+  end
+
   context 'overriding control alt delete (stig: V-38668)' do
     describe file('/etc/init/control-alt-delete.override') do
       it { should be_file }

--- a/stemcell_builder/stages/clean_machine_id/apply.sh
+++ b/stemcell_builder/stages/clean_machine_id/apply.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+
+# machine-id should be unique for each created vm.
+echo "" > $chroot/etc/machine-id
+rm -f $chroot/var/lib/dbus/machine-id


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/122.

Tested on azure with three instances:

```
>>  bosh -d dummy ssh dummy -c "sudo cat /etc/machine-id"

Task 1019. Done
dummy/f72702f5-8caa-42ce-a6ee-c830c95cdec6: stdout | 85b2b7878ca74dbdb690fca4cb48979f
dummy/c9f423ad-8679-445c-9cf1-ca3594e4b9d9: stdout | c221dcc781784119bbf8acc82be15171
dummy/00345530-4aed-4b71-9449-e824e98e4510: stdout | c0c5b162af0e4b15912d42b459604892

Succeeded
```
