### PR TITLE
build stemcell for CloudStack with Xen

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
@@ -172,6 +172,8 @@ module Bosh::Stemcell
         ' --tag ~exclude_on_aws'
       when 'openstack'
         ' --tag ~exclude_on_openstack'
+      when 'cloudstack'
+        ' --tag ~exclude_on_cloudstack'
       when 'azure'
         ' --tag ~exclude_on_azure'
       when 'softlayer'

--- a/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
@@ -20,6 +20,8 @@ module Bosh::Stemcell
           Azure.new
         when 'softlayer'
           Softlayer.new
+        when 'cloudstack'
+          CloudStack.new
         when 'null'
           NullInfrastructure.new
         else
@@ -74,6 +76,16 @@ module Bosh::Stemcell
           disk_formats: ['qcow2', 'raw'],
           stemcell_formats: ['openstack-qcow2', 'openstack-raw']
         )
+      end
+
+      def additional_cloud_properties
+        {'auto_disk_config' => true}
+      end
+    end
+
+    class CloudStack < Base
+      def initialize
+        super(name: 'cloudstack', hypervisor: 'xen', default_disk_size: 3072, disk_formats: ['vhdx'], stemcell_formats: ['cloudstack-vhdx'])
       end
 
       def additional_cloud_properties

--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -37,6 +37,8 @@ module Bosh::Stemcell
                  aws_stages
                when Infrastructure::Alicloud then
                  alicloud_stages
+               when Infrastructure::CloudStack then
+                 cloudstack_stages
                when Infrastructure::Google then
                  google_stages
                when Infrastructure::OpenStack then
@@ -68,6 +70,8 @@ module Bosh::Stemcell
         ovf_package_stages
       when 'vhd' then
         vhd_package_stages
+      when 'vhdx' then
+        vhdx_package_stages
       when 'files' then
         files_package_stages
       end
@@ -91,6 +95,24 @@ module Bosh::Stemcell
         image_install_grub
       ]
     end
+
+    def cloudstack_stages
+      %i[
+        system_network
+        system_openstack_modules
+        bosh_cloudstack_ubuntu_vr_metadata
+        system_ubuntu_xen_tools
+        system_parameters
+        system_vhd_utils_tools
+        bosh_clean
+        bosh_harden
+        bosh_cloudstack_agent_settings
+        bosh_clean_ssh
+        image_create
+        image_install_grub
+      ]
+    end
+
 
     def vsphere_vcloud_stages
       [
@@ -293,6 +315,12 @@ module Bosh::Stemcell
     def vhd_package_stages
       [
         :prepare_vhd_image_stemcell,
+      ]
+    end
+
+    def vhdx_package_stages
+      [
+        :prepare_vhdx_image_stemcell,
       ]
     end
 

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-bionic-cloudstack-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-bionic-cloudstack-additions.txt
@@ -1,0 +1,3 @@
+libxenstore3.0:amd64
+xe-guest-utilities
+xenstore-utils

--- a/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
@@ -13,6 +13,7 @@ module Bosh::Stemcell
         expect(Infrastructure.for('vcloud')).to be_a(Infrastructure::Vcloud)
         expect(Infrastructure.for('azure')).to be_a(Infrastructure::Azure)
         expect(Infrastructure.for('softlayer')).to be_a(Infrastructure::Softlayer)
+        expect(Infrastructure.for('cloudstack')).to be_a(Infrastructure::CloudStack)
         expect(Infrastructure.for('null')).to be_an(Infrastructure::NullInfrastructure)
       end
 
@@ -120,6 +121,20 @@ module Bosh::Stemcell
     it { should_not eq Infrastructure.for('vsphere') }
 
     it 'has openstack specific additional cloud properties' do
+      expect(subject.additional_cloud_properties).to eq({'auto_disk_config' => true})
+    end
+  end
+
+  describe Infrastructure::CloudStack do
+    its(:name)              { should eq('cloudstack') }
+    its(:hypervisor)        { should eq('xen') }
+    its(:default_disk_size) { should eq(3072) }
+    its(:disk_formats) {should eq(['vhdx'])}
+
+    it { should eq Infrastructure.for('cloudstack') }
+    it { should_not eq Infrastructure.for('vsphere') }
+
+    it 'has cloudstack specific additional cloud properties' do
       expect(subject.additional_cloud_properties).to eq({'auto_disk_config' => true})
     end
   end

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -206,6 +206,34 @@ module Bosh::Stemcell
         end
       end
 
+      context 'when using CloudStack' do
+        let(:infrastructure) { Infrastructure.for('cloudstack') }
+        let(:operating_system) { OperatingSystem.for('ubuntu') }
+
+        it 'has the correct stages' do
+          expect(stage_collection.build_stemcell_image_stages).to eq(
+            [
+              :system_network,
+              :system_openstack_clock,
+              :system_openstack_modules,
+              :system_parameters,
+              :bosh_clean,
+              :bosh_harden,
+              :bosh_openstack_agent_settings,
+              :bosh_clean_ssh,
+              :image_create,
+              :image_install_grub,
+              :bosh_package_list
+            ]
+          )
+          expect(stage_collection.package_stemcell_stages('qcow2')).to eq(
+              [
+                :prepare_qcow2_image_stemcell,
+              ]
+          )
+        end
+      end
+
       context 'when using vSphere' do
         let(:infrastructure) { Infrastructure.for('vsphere') }
         let(:operating_system) { OperatingSystem.for('ubuntu') }

--- a/bosh-stemcell/spec/stemcells/cis_spec.rb
+++ b/bosh-stemcell/spec/stemcells/cis_spec.rb
@@ -49,7 +49,7 @@ describe 'CIS test case verification', {stemcell_image: true, security_spec: tru
   end
 
 
-  context "For all infrastructure except Azure", {exclude_on_azure:true} do
+  context "For all infrastructure except Azure and Cloudstack", {exclude_on_azure:true, exclude_on_cloudstack:true} do
     it 'confirms that all CIS test cases ran' do
       expect($cis_test_cases.to_a).to match_array(base_cis_test_cases + ['CIS-2.24'])
     end
@@ -63,6 +63,7 @@ describe 'CIS test case verification', {stemcell_image: true, security_spec: tru
     exclude_on_vsphere: true,
     exclude_on_warden: true,
     exclude_on_openstack: true,
+    exclude_on_cloudstack: true,
     exclude_on_softlayer: true,
   } do
     it 'confirms that all CIS test cases ran' do

--- a/bosh-stemcell/spec/stemcells/cloudstack_spec.rb
+++ b/bosh-stemcell/spec/stemcells/cloudstack_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'CloudStack Stemcell', stemcell_image: true do
+  context 'installed by system_parameters' do
+    describe file('/var/vcap/bosh/etc/infrastructure') do
+      its(:content) { should match('cloudstack') }
+    end
+  end
+
+
+  context 'installed by bosh_disable_password_authentication' do
+    describe 'disallows password authentication' do
+      subject { file('/etc/ssh/sshd_config') }
+
+      its(:content) { should match /^PasswordAuthentication no$/ }
+    end
+  end
+end

--- a/bosh-stemcell/spec/stemcells/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_bionic_spec.rb
@@ -8,6 +8,19 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by image_install_grub', {
     exclude_on_softlayer: true
   } do
+    context 'for cloudstack infrastructure and xen hypervisor', {
+        exclude_on_aws: true,
+        exclude_on_vcloud: true,
+        exclude_on_vsphere: true,
+        exclude_on_google: true,
+        exclude_on_warden: true,
+        exclude_on_azure: true,
+        exclude_on_openstack: true,
+    } do
+      describe file('/boot/grub/grub.cfg') do
+        its(:content) { should match ' console=hvc0' }
+      end
+    end
     describe file('/boot/grub/grub.cfg') do
       it { should be_file }
       its(:content) { should match 'set default="0"' }
@@ -35,6 +48,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by image_install_grub_softlayer_two_partitions', {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_google: true,
       exclude_on_vsphere: true,
       exclude_on_vcloud: true,
@@ -70,6 +84,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
     exclude_on_alicloud: true,
     exclude_on_aws: true,
     exclude_on_azure: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_vcloud: true,
     exclude_on_vsphere: true,
@@ -147,6 +162,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by system-azure-network', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_vcloud: true,
     exclude_on_vsphere: true,
@@ -164,6 +180,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by system_open_vm_tools', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_vcloud: true,
     exclude_on_warden: true,
@@ -179,6 +196,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by system_softlayer_open_iscsi', {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_google: true,
       exclude_on_vsphere: true,
       exclude_on_vcloud: true,
@@ -194,6 +212,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by system_softlayer_multipath_tools', {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_google: true,
       exclude_on_vsphere: true,
       exclude_on_vcloud: true,
@@ -209,6 +228,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by system_softlayer_netplan', {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_google: true,
       exclude_on_vsphere: true,
       exclude_on_vcloud: true,
@@ -224,6 +244,7 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
   context 'installed by image_vsphere_cdrom stage', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_vcloud: true,
     exclude_on_warden: true,
@@ -261,6 +282,7 @@ HERE
 
   context 'installed by bosh_alicloud_agent_settings', {
     exclude_on_aws: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_openstack: true,
     exclude_on_vcloud: true,
@@ -277,6 +299,7 @@ HERE
 
   context 'installed by bosh_aws_agent_settings', {
     exclude_on_alicloud: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_openstack: true,
     exclude_on_vcloud: true,
@@ -294,6 +317,7 @@ HERE
   context 'installed by bosh_google_agent_settings', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,
+    exclude_on_cloudstack: true,
     exclude_on_openstack: true,
     exclude_on_vcloud: true,
     exclude_on_vsphere: true,
@@ -310,6 +334,7 @@ HERE
   context 'installed by bosh_openstack_agent_settings', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_vcloud: true,
     exclude_on_vsphere: true,
@@ -328,6 +353,7 @@ HERE
   context 'installed by bosh_vsphere_agent_settings', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,
+    exclude_on_cloudstack: true,
     exclude_on_google: true,
     exclude_on_vcloud: true,
     exclude_on_openstack: true,
@@ -344,6 +370,7 @@ HERE
   context 'installed by bosh_softlayer_agent_settings', {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_google: true,
       exclude_on_vcloud: true,
       exclude_on_vsphere: true,
@@ -356,6 +383,23 @@ HERE
       its(:content) { should match('"Type": "HTTP"') }
       its(:content) { should match('"UserDataPath": "/rest/v3.1/SoftLayer_Resource_Metadata/getUserMetadata.json"') }
       its(:content) { should match('"UseRegistry": true') }
+    end
+  end
+
+  context 'installed by bosh_cloudstack_agent_settings', {
+      exclude_on_aws: true,
+      exclude_on_vcloud: true,
+      exclude_on_vsphere: true,
+      exclude_on_warden: true,
+      exclude_on_azure: true,
+      exclude_on_openstack: true,
+      exclude_on_google: true,
+      exclude_on_softlayer: true,
+  } do
+    describe file('/var/vcap/bosh/agent.json') do
+      it { should be_valid_json_file }
+      its(:content) { should match('"CreatePartitionIfNoEphemeralDisk": true') }
+      its(:content) { should match('"Type": "HTTP"') }
     end
   end
 
@@ -381,9 +425,11 @@ HERE
     let(:dpkg_list_google_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-bionic-google-additions.txt')).map(&:chop) }
     let(:dpkg_list_vsphere_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-bionic-vsphere-additions.txt')).map(&:chop) }
     let(:dpkg_list_azure_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-bionic-azure-additions.txt')).map(&:chop) }
+    let(:dpkg_list_cloudstack_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-bionic-cloudstack-additions.txt')).map(&:chop) }
     let(:dpkg_list_softlayer_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-bionic-softlayer-additions.txt')).map(&:chop) }
 
     describe command(dpkg_list_packages), {
+      exclude_on_cloudstack: true,
       exclude_on_google: true,
       exclude_on_vcloud: true,
       exclude_on_vsphere: true,
@@ -398,6 +444,7 @@ HERE
     describe command(dpkg_list_packages), {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_vcloud: true,
       exclude_on_vsphere: true,
       exclude_on_warden: true,
@@ -413,6 +460,7 @@ HERE
     describe command(dpkg_list_packages), {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_google: true,
       exclude_on_warden: true,
       exclude_on_azure: true,
@@ -427,6 +475,7 @@ HERE
     describe command(dpkg_list_packages), {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_vcloud: true,
       exclude_on_vsphere: true,
       exclude_on_google: true,
@@ -440,8 +489,23 @@ HERE
     end
 
     describe command(dpkg_list_packages), {
+      exclude_on_aws: true,
+      exclude_on_vcloud: true,
+      exclude_on_vsphere: true,
+      exclude_on_google: true,
+      exclude_on_warden: true,
+      exclude_on_azure: true,
+      exclude_on_openstack: true,
+    } do
+      it 'contains only the base set of packages plus cloudstack-specific packages' do
+        expect(subject.stdout.split("\n")).to match_array(dpkg_list_ubuntu.concat(dpkg_list_cloudstack_ubuntu))
+      end
+    end
+
+    describe command(dpkg_list_packages), {
       exclude_on_alicloud: true,
       exclude_on_aws: true,
+      exclude_on_cloudstack: true,
       exclude_on_vcloud: true,
       exclude_on_vsphere: true,
       exclude_on_google: true,

--- a/bosh-stemcell/spec/support/stemcell_shared_examples.rb
+++ b/bosh-stemcell/spec/support/stemcell_shared_examples.rb
@@ -117,6 +117,7 @@ HERE
       exclude_on_google: true,
       exclude_on_vcloud: true,
       exclude_on_vsphere: true,
+      exclude_on_cloudstack: true,
       exclude_on_azure: true,
       exclude_on_openstack: true,
     } do

--- a/stemcell_builder/lib/helpers.sh
+++ b/stemcell_builder/lib/helpers.sh
@@ -34,7 +34,7 @@ function run_in_chroot {
     mkdir -p $chroot/proc
     mount -n --bind /proc $chroot/proc
 
-    chroot $chroot env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin http_proxy=${http_proxy:-} bash -e -c "$script"
+    chroot $chroot env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin http_proxy=${http_proxy:-} https_proxy=${https_proxy:-} no_proxy=${no_proxy:-} bash -e -c "$script"
 EOS
 
   # Enable daemon startup
@@ -85,3 +85,12 @@ curl_five_times() {
   fi
   set -e
 }
+
+function is_x86_64() {
+  if [ `uname -m` == "x86_64" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/lib/prelude_agent.bash
+
+agent_settings_file=$chroot/var/vcap/bosh/agent.json
+
+cat > $agent_settings_file <<JSON
+{
+  "Platform": {
+    "Linux": {
+      $(get_partitioner_type_mapping)
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "virtio"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "http://169.254.169.254:39724",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys"
+        }
+      ],
+      "UseServerName": true,
+      "UseRegistry": true
+    }
+  }
+}
+JSON

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/config.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_config.bash
+
+persist stemcell_operating_system

--- a/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/apply.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/apply.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf "$(dirname "$0")/../..")
+source "$base_dir/lib/prelude_apply.bash"
+
+
+
+mkdir -p "$chroot/tmp/mdproxy4cs/"
+cp "$(dirname "$0")/assets/install.sh" "$chroot/tmp/mdproxy4cs/"
+chmod +x "$chroot/tmp/mdproxy4cs/install.sh"
+
+run_in_chroot "$chroot" "/tmp/mdproxy4cs/install.sh"

--- a/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/assets/install.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/assets/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+repo="orange-cloudfoundry/mdproxy4cs"
+version="1.0.0"
+name="mdproxy4cs-${version}.linux-amd64"
+file="${name}.tar.gz"
+dir=$(mktemp -d)
+
+cd "${dir}"
+
+curl -fsL "https://github.com/${repo}/releases/download/v${version}/${file}" |
+tar xz
+
+mkdir -p /usr/share/mdproxy4cs/
+
+cp "${name}/mdproxy4cs"         /usr/bin/
+cp "${name}/pre-start.sh"       /usr/share/mdproxy4cs/pre-start.sh
+cp "${name}/mdproxy4cs.service" /usr/share/mdproxy4cs/mdproxy4cs.service
+cp "${name}/default"            /etc/default/mdproxy4cs
+
+systemctl enable /usr/share/mdproxy4cs/mdproxy4cs.service
+
+rm -rf "${dir}"

--- a/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/config.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf "$(dirname "$0")/../..")
+source "$base_dir/lib/prelude_config.bash"
+
+persist stemcell_operating_system

--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -75,9 +75,14 @@ run_in_chroot ${image_mount_point} "grub-install -v --no-floppy --grub-mkdevicem
 run_in_chroot ${image_mount_point} "sed -i 's/CLASS=\\\"--class gnu-linux --class gnu --class os\\\"/CLASS=\\\"--class gnu-linux --class gnu --class os --unrestricted\\\"/' /etc/grub.d/10_linux"
 
 grub_suffix=""
-if [ "${stemcell_infrastructure}" == "aws" ]; then
+case "${stemcell_infrastructure}" in
+aws)
   grub_suffix="nvme_core.io_timeout=4294967295"
-fi
+  ;;
+cloudstack)
+  grub_suffix="console=hvc0"
+  ;;
+esac
 
 cat >${image_mount_point}/etc/default/grub <<EOF
 GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 ${grub_suffix}"

--- a/stemcell_builder/stages/prepare_vhdx_image_stemcell/apply.sh
+++ b/stemcell_builder/stages/prepare_vhdx_image_stemcell/apply.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+set -e
+
+base_dir=$(readlink -nf "$(dirname "$0")/../..")
+source "$base_dir/lib/prelude_apply.bash"
+
+rm -f "$work/root.vhd"
+
+# Convert raw to dynamic VHD
+qemu-img convert -O vpc -o subformat=dynamic "$work/${stemcell_image_name}" "$work/root.vhd"
+
+#Verification:
+vhd-util check -n "$work/root.vhd"
+vhd-util read -p -n "$work/root.vhd"
+ls -lh "$work/root.vhd"
+
+pushd "$work"
+"$(command -v lbzip2 2>/dev/null || command -v bzip2)" -c root.vhd > stemcell/image
+popd

--- a/stemcell_builder/stages/prepare_vhdx_image_stemcell/config.sh
+++ b/stemcell_builder/stages/prepare_vhdx_image_stemcell/config.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf "$(dirname "$0")/../..")
+source "$base_dir/lib/prelude_config.bash"
+
+assert_available qemu-img
+persist_value stemcell_image_name
+
+stemcell_disk_format=vhd
+persist_value stemcell_disk_format

--- a/stemcell_builder/stages/system_ubuntu_xen_tools/apply.sh
+++ b/stemcell_builder/stages/system_ubuntu_xen_tools/apply.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf "$(dirname "$0")/../..")
+source "$base_dir/lib/prelude_apply.bash"
+source "$base_dir/etc/settings.bash"
+
+debs="xe-guest-utilities xenstore-utils"
+
+pkg_mgr install $debs
+
+set -u
+
+# xen-tools configuration
+file=${chroot}/etc/sysctl.conf
+sed -i -e 's/\(^\s*net\.ipv4\.conf\.[^.]\+\.arp_notify\s*=\s*0\)/#Auto-disabled by xs-tools:install.sh\n#\1/' "${file}"
+printf '# Auto-enabled by xs-tools:install.sh\nnet.ipv4.conf.all.arp_notify = 1\n' >> "${file}"

--- a/stemcell_builder/stages/system_vhd_utils_tools/apply.sh
+++ b/stemcell_builder/stages/system_vhd_utils_tools/apply.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf "$(dirname "$0")/../..")
+source "$base_dir/lib/prelude_apply.bash"
+
+
+sudo env http_proxy="${http_proxy:-}" https_proxy="${https_proxy:-}" no_proxy="${no_proxy:-}" \
+apt-get install -y uuid-dev
+sudo env http_proxy="${http_proxy:-}" https_proxy="${https_proxy:-}" no_proxy="${no_proxy:-}" \
+apt-get install -y lbzip2 || true
+
+cd /tmp
+rm -rf vhd-util-convert
+git clone --depth 1 https://github.com/rubiojr/vhd-util-convert
+cd vhd-util-convert
+make
+sudo cp vhd-util /usr/local/bin/


### PR DESCRIPTION
This patch make it possible to build a stemcell to be used on the Xen hypervisor under CloudStack orchestrator.

It is currently used with CloudStack ≥ 4.11 and XenServer 7 and build on top an Ubuntu Bionic base image.

Usage:

    bundle exec rake stemcell:build_with_local_os_image[cloudstack,xen,ubuntu,bionic,$PWD/tmp/ubuntu_base_image.tgz,"1.23"]

## Notes

1. This PR is derived from a series of patches we have been used for years in production on top the *Ubuntu Xenial* image which has reached it's end of life earlier this year; meaning it *does* have some Xenial leftovers in the code but is now build on top the Bionic releases.
2. While working on this PR for Bionic, we noticed the virtual machines network interface `eth0` was left in a "down" state when we used we used (`stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-version`) a recent (`v2.366.0`) version of the bosh-agent; however it does work as expected with the `v2.346.0` version.

We would welcome any feedback on this pull request and additional requirements needed for it to be accepted.

Cheers,
Romain.