### PR TITLE
Fixes rsyslog configuration files issues

### DIFF
--- a/bosh-stemcell/spec/stemcells/google_spec.rb
+++ b/bosh-stemcell/spec/stemcells/google_spec.rb
@@ -8,7 +8,6 @@ describe 'Google Stemcell', stemcell_image: true do
       it 'match expected list of rsyslog configs' do
         expected_rsyslog_confs = %w(50-default.conf
 90-google.conf
-enable-kernel-logging.conf
 )
 
 

--- a/bosh-stemcell/spec/support/stemcell_shared_examples.rb
+++ b/bosh-stemcell/spec/support/stemcell_shared_examples.rb
@@ -91,7 +91,6 @@ shared_examples_for 'All Stemcells' do
       its (:stdout) do
         should eq(<<~FILELIST)
           50-default.conf
-          enable-kernel-logging.conf
         FILELIST
       end
     end

--- a/stemcell_builder/stages/rsyslog_config/apply.sh
+++ b/stemcell_builder/stages/rsyslog_config/apply.sh
@@ -19,8 +19,6 @@ else
   mkdir -p $chroot/etc/rsyslog.d
 fi
 
-cp $assets_dir/enable-kernel-logging.conf $chroot/etc/rsyslog.d/enable-kernel-logging.conf
-
 cp -f $assets_dir/rsyslog_50-default.conf $chroot/etc/rsyslog.d/50-default.conf
 
 # Add user/group


### PR DESCRIPTION
It seemed based on the order the PRs 

- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/168
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/169

have been merged, some removed code popped up again.