### PR TITLE
Monit isolation bionic/master

### DIFF
--- a/stemcell_builder/lib/iptables_common_definitions.bash
+++ b/stemcell_builder/lib/iptables_common_definitions.bash
@@ -1,0 +1,13 @@
+# This is the integer value of the argument "0xb0540001", which is
+# b054:0001 . The major number (the left-hand side) is "BOSH", leet-ified.
+# The minor number (the right-hand side) is 1, indicating that this is the
+# first thing in our "BOSH" classid namespace.
+#
+# _Hopefully_ noone uses a major number of "b054", and we avoid collisions _forever_!
+# If you need to select new classids for firewall rules or traffic control rules, keep
+# the major number "b054" for bosh stuff, unless there's a good reason to not.
+#
+# The net_cls.classid structure is described in more detail here:
+# https://www.kernel.org/doc/Documentation/cgroup-v1/net_cls.txt
+
+monit_isolation_classid=2958295041

--- a/stemcell_builder/stages/bosh_go_agent/assets/runit/agent/run
+++ b/stemcell_builder/stages/bosh_go_agent/assets/runit/agent/run
@@ -4,6 +4,10 @@ set -e
 export PATH=/var/vcap/bosh/bin:$PATH
 exec 2>&1
 
+source /var/vcap/bosh/etc/monit-access-helper.sh
+
+permit_monit_access
+
 cd /var/vcap/bosh
 
 exec nice -n -15 /var/vcap/bosh/bin/bosh-agent -P $(cat /var/vcap/bosh/etc/operating_system) -C /var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_monit/apply.sh
+++ b/stemcell_builder/stages/bosh_monit/apply.sh
@@ -5,7 +5,6 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
-source $base_dir/lib/iptables_common_definitions.bash
 
 monit_basename=monit-5.2.5
 monit_archive=$monit_basename.tar.gz
@@ -29,39 +28,12 @@ chmod 0700 $chroot/$bosh_dir/etc/monitrc
 mkdir -p $chroot/$bosh_app_dir/monit
 touch $chroot/$bosh_app_dir/monit/empty.monitrc
 
-mv $chroot/$bosh_dir/bin/monit $chroot/$bosh_dir/bin/monit-actual
 # Monit wrapper script:
+mv $chroot/$bosh_dir/bin/monit $chroot/$bosh_dir/bin/monit-actual
 
-cat > $chroot/$bosh_dir/bin/monit <<EOF
-#/bin/bash
-
-set -e
-EOF
-
-echo $'net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk \'{ print $2 }\' )"' >> $chroot/$bosh_dir/bin/monit
-
-cat >> $chroot/$bosh_dir/bin/monit <<EOF
-mkdir "\$net_cls_location"/monit-api-access || true
-echo $monit_isolation_classid > "\$net_cls_location"/monit-api-access/net_cls.classid
-EOF
-
-cat >> $chroot/$bosh_dir/bin/monit <<'EOF'
-echo $$ > "\$net_cls_location"/monit-api-access/tasks
-exec monit-actual $@
-EOF
-
+cp $dir/assets/monit-access-helper.sh $chroot/$bosh_dir/etc/
+cp $dir/assets/monit $chroot/$bosh_dir/bin/monit
 chmod +x $chroot/$bosh_dir/bin/monit
 
-
-cat > $chroot/etc/network/if-up.d/restrict-monit-api-access <<EOF
-#!/bin/bash
-
-if iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 -m cgroup \! --cgroup $monit_isolation_classid -j DROP
-then
-  /bin/true
-else
-  iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 -m cgroup \! --cgroup $monit_isolation_classid -j DROP
-fi
-EOF
-
+cp $dir/assets/restrict-monit-api-access $chroot/etc/network/if-up.d/restrict-monit-api-access
 chmod +x $chroot/etc/network/if-up.d/restrict-monit-api-access

--- a/stemcell_builder/stages/bosh_monit/apply.sh
+++ b/stemcell_builder/stages/bosh_monit/apply.sh
@@ -5,6 +5,7 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
+source $base_dir/lib/iptables_common_definitions.bash
 
 monit_basename=monit-5.2.5
 monit_archive=$monit_basename.tar.gz
@@ -27,3 +28,40 @@ chmod 0700 $chroot/$bosh_dir/etc/monitrc
 # monit refuses to start without an include file present
 mkdir -p $chroot/$bosh_app_dir/monit
 touch $chroot/$bosh_app_dir/monit/empty.monitrc
+
+mv $chroot/$bosh_dir/bin/monit $chroot/$bosh_dir/bin/monit-actual
+# Monit wrapper script:
+
+cat > $chroot/$bosh_dir/bin/monit <<EOF
+#/bin/bash
+
+set -e
+EOF
+
+echo $'net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk \'{ print $2 }\' )"' >> $chroot/$bosh_dir/bin/monit
+
+cat >> $chroot/$bosh_dir/bin/monit <<EOF
+mkdir "\$net_cls_location"/monit-api-access || true
+echo $monit_isolation_classid > "\$net_cls_location"/monit-api-access/net_cls.classid
+EOF
+
+cat >> $chroot/$bosh_dir/bin/monit <<'EOF'
+echo $$ > "\$net_cls_location"/monit-api-access/tasks
+exec monit-actual $@
+EOF
+
+chmod +x $chroot/$bosh_dir/bin/monit
+
+
+cat > $chroot/etc/network/if-up.d/restrict-monit-api-access <<EOF
+#!/bin/bash
+
+if iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 -m cgroup \! --cgroup $monit_isolation_classid -j DROP
+then
+  /bin/true
+else
+  iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 -m cgroup \! --cgroup $monit_isolation_classid -j DROP
+fi
+EOF
+
+chmod +x $chroot/etc/network/if-up.d/restrict-monit-api-access

--- a/stemcell_builder/stages/bosh_monit/assets/monit
+++ b/stemcell_builder/stages/bosh_monit/assets/monit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source /var/vcap/bosh/etc/monit-access-helper.sh
+
+permit_monit_access
+
+exec monit-actual $@

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -11,3 +11,13 @@
 # https://www.kernel.org/doc/Documentation/cgroup-v1/net_cls.txt
 
 monit_isolation_classid=2958295041
+
+permit_monit_access() {
+    net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk '{ print $2 }' )"
+    monit_access_cgroup="${net_cls_location}/monit-api-access"
+
+    mkdir -p "${monit_access_cgroup}"
+    echo "${monit_isolation_classid}" > "${monit_access_cgroup}/net_cls.classid"
+
+    echo $$ > "${monit_access_cgroup}/tasks"
+}

--- a/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
+++ b/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source /var/vcap/bosh/etc/monit-access-helper.sh
+
+if iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+	    -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
+then
+  /bin/true
+else
+    iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+	     -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
+fi


### PR DESCRIPTION
This PR adds a file to be used to place magic numbers used in
iptables rules and the scripts that power them.

It also updates the `bosh_monit` OS Image Generation Step to
* Drop a file in `if-up.d` that sets our "Drop packets to the monit api
  endpoint if they're not coming from the monit cli" iptables rule if
  it does not already exist.
* Renames the `monit` CLI and Creates a wrapper for the `monit` CLI that
  ensures that the `monit` CLI is in the cgroup that has access to the
  monit API.

[#178437277] Prevent authentication to monit localhost HTTP API server from a malicious Kubernetes workload