### PR TITLE
Do nothing in response to cdrom eject request

### DIFF
--- a/stemcell_builder/stages/system_vsphere_cdrom/assets/60-cdrom_id.rules
+++ b/stemcell_builder/stages/system_vsphere_cdrom/assets/60-cdrom_id.rules
@@ -9,7 +9,15 @@ ENV{DEVTYPE}!="disk", GOTO="cdrom_end"
 KERNEL=="sr[0-9]*", ENV{ID_CDROM}="1"
 
 # media eject button pressed
-ENV{DISK_EJECT_REQUEST}=="?*", RUN+="cdrom_id --eject-media $devnode", GOTO="cdrom_end"
+# NOTE: As of Stemcell versions 621.151 and 456.186, ejecting the media in response to an eject request event results in
+#       a storm of media change events from the kernel for several minutes. During this event storm, any media
+#       reinserted will not be recognized. After the storm is over, inserted media will be correctly recognized again.
+#       (Both affected stemcell versions are using kernel version 4.15.0-156)
+#       Testing has revealed that -because we do not lock the drive door- we can simply do nothing in reponse to an eject
+#       request, and everything works as required.
+#       So, because Canonical will likely take some time to figure out what's going wrong and release a patch, and because
+#       fixing this is high-priority, we're just going to not do anything in response to an eject request.
+# ENV{DISK_EJECT_REQUEST}=="?*", RUN+="cdrom_id --eject-media $devnode", GOTO="cdrom_end"
 
 # Do not lock CDROM drive when cdrom is inserted
 # because vSphere will start asking questions via API.


### PR DESCRIPTION
Hi, folks!

While working on the Xenial stemcells, we discovered that a recent kernel version bump resulted in an inability to reliably attach persistent disks on the vSphere IAAS. We tracked down the problem to _some_ change (we never bothered to figure out which) in kernel version 4.15.0-156 that causes a several-minute event storm when you ask udev to eject the media in the device that has generated a media eject request.

Because we think that the Bionic stemcell is using this same kernel version, and because (while looking at the Changelog for the ESM Xenial kernel) we saw evidence that Bionic kernel patches were getting merged into our Xenial kernel, we believe that you folks are also affected by this problem.

This PR comments out the thing in the `udev` rule that causes the event storm to happen. **NOTE**: this udev rule is only added to the vSphere images, so if you want to test to see if you're affected, you'll have to deploy the vSphere stemcell.

I've based this off of the `ubuntu-bionic/master` branch, but it will likely cleanly apply to any branch that you folks have.

Do let me know if you have any questions or concerns, or would like me to resubmit this thing, but based on a different branch.

Commit message (which contains some more detail about the problem) follows:

===================================================================================

As of Stemcell versions 621.151 and 456.186, ejecting the media in response to an eject request event results in
a storm of media change events from the kernel for several minutes. During this event storm, any media
reinserted will not be recognized. After the storm is over, inserted media will be correctly recognized again.
(Both affected stemcell versions are using kernel version 4.15.0-156)

Testing has revealed that -because we do not lock the drive door- we can simply do nothing in reponse to an eject
request, and everything works as required.

So, because Canonical will likely take some time to figure out what's going wrong and release a patch, and because
fixing this is high-priority, we're just going to not do anything in response to an eject request.

[#179598052] Explore canonical vsphere changes