### PR TITLE
🐞 vCenter correctly displays IP address of VMs

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_bionic_spec.rb
@@ -136,6 +136,11 @@ describe 'Ubuntu 18.04 stemcell image', stemcell_image: true do
     describe package('open-vm-tools') do
       it { should be_installed }
     end
+    describe file('/etc/vmware-tools/tools.conf') do
+      it { should be_file }
+      its(:content) { should match '\[guestinfo\]' }
+      its(:content) { should match 'exclude-nics=veth\*,docker\*,virbr\*,silk-vtep,s-\*,ovs\*,erspan\*,nsx-container,antrea\*,\?\?\?\?\?\?\?\?\?\?\?\?\?\?\?' }
+    end
   end
 
   context 'installed by system_softlayer_open_iscsi', {

--- a/stemcell_builder/stages/system_open_vm_tools/apply.sh
+++ b/stemcell_builder/stages/system_open_vm_tools/apply.sh
@@ -12,6 +12,12 @@ pkg_mgr install open-vm-tools
 # open-vm-tools installs unwanted fusermount binary
 run_in_chroot $chroot "rm -f /usr/bin/fusermount"
 
+# exclude container interface IPs preventing VM interface IPs displaying on vCenter UI
+cat >> $chroot/etc/vmware-tools/tools.conf <<EOF
+[guestinfo]
+exclude-nics=veth*,docker*,virbr*,silk-vtep,s-*,ovs*,erspan*,nsx-container,antrea*,???????????????
+EOF
+
 # The above installation adds a PAM configuration with 'nullok' values in it.
 # We need to get rid of those as per stig V-38497.
 sed -i -r 's/\bnullok[^ ]*//g' $chroot/etc/pam.d/vmtoolsd


### PR DESCRIPTION

This bug only affected VMs which run containers, for example Kubernetes worker nodes and Cloud Foundry Diego cells. The bug would manifest as an empty IP address on the vCenter UI in the VM's Summary page next to the "IP Addresses" field.

The cause appears to be the containers' network interfaces confusing `toolsd`, the executable of the "open-vm-tools" package which relays information about the VM to the vCenter.

This commit remedies this problem by directing `toolsd` to ignore specific patterns of ethernet NICs when searching for the IP address of the VM; it does so by blacklisting NICs in the `/etc/vmware-tools/tools.conf` configuration file.

Thi is the list of NIC patterns we ignore. The first bullet is the [default pattern
list](https://github.com/vmware/open-vm-tools/blob/677ddf97a85f8b96b95ac60f54b59df264d5c4d5/open-vm-tools/tools.conf#L224-L225):

- `veth*,docker*,virbr*` (default)
- `silk-vtep,s-*` (Silk: Cloud Foundry container overlay network)
- `ovs*,erspan*,nsx-container` (NCP: NSX-T Container Plug-in and Open vSwitch)
- `antrea*` (NEW: another overlay network for containers)
- `???????????????` (NEW: ignore all max-length interface names)

Note: `eth0` is typically the NIC which contains the correct IP address of the VM; all other NICs are suspect.

The maximum length of a network interface name is 15 bytes (with the null terminator bringing it to [16](https://github.com/spotify/linux/blob/master/include/linux/if.h#L26))

_[I was not able to run tests; I got `ERROR [ 2/11] RUN groupadd -g 20 ubuntu && useradd -u 501 -g 20 -m ubuntu   && echo 'ubuntu ALL=NOPASSWD:ALL' >> /etc/sudoers` when I tried `run os-image-stemcell-builder`]_