### PR TITLE
ci/docker: Fix ovftool eula agreement

### DIFF
--- a/ci/docker/os-image-stemcell-builder/scripts/install-ovf.sh
+++ b/ci/docker/os-image-stemcell-builder/scripts/install-ovf.sh
@@ -5,6 +5,5 @@ set -ex
 cd /tmp
 echo "${OVF_TOOL_INSTALLER_SHA1} /tmp/ovftool_installer.bundle" | sha1sum -c -
 chmod a+x ./ovftool_installer.bundle
-ln -s /bin/cat /usr/local/bin/more
-echo -e "\nyes\n\n" | bash  ./ovftool_installer.bundle
+bash  ./ovftool_installer.bundle --eulas-agreed
 rm -rf ./ovftool_installer.bundle /tmp/vmware-root/ /usr/local/bin/more


### PR DESCRIPTION
With newer versions (VMware-ovftool-4.1.0-2459827-lin.x86_64.bundle
for me), the docker build does hang while trying to accept the eula.
Using the available --eulas-agreed flag when running the installer
solve that problem.