### PR TITLE
Drop RHN_USERNAME and RHN_PASSWORD env vars

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
@@ -61,8 +61,6 @@ module Bosh::Stemcell
       {
         'UBUNTU_ISO' => environment['UBUNTU_ISO'],
         'UBUNTU_MIRROR' => environment['UBUNTU_MIRROR'],
-        'RHN_USERNAME' => environment['RHN_USERNAME'],
-        'RHN_PASSWORD' => environment['RHN_PASSWORD'],
       }
     end
 


### PR DESCRIPTION
The functionality using those environment variables was already
removed in commit 6acd0c9cf71edd6. So this commit is just cleaning up
the leftovers.