### PR TITLE
downgraded to gcc/g++ 9. Package compile scripts

### DIFF
--- a/stemcell_builder/stages/base_ubuntu_build_essential/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_build_essential/apply.sh
@@ -10,3 +10,5 @@ debconf="debconf debconf/frontend select noninteractive"
 run_in_chroot $chroot "echo ${debconf} | debconf-set-selections"
 
 pkg_mgr install build-essential
+pkg_mgr install gcc-9 g++-9
+pkg_mgr purge gcc-10 g++-10


### PR DESCRIPTION
gcc10 introduced a new default flag -fno-common:
https://gcc.gnu.org/gcc-10/porting_to.html

this will break releases that have build dependencies because some (currently known haproxy, xfx-progs,percona-xtrabackup) release have code that is not following gcc10 requirement to mark global vars with `extern`.

building a wrapper around gcc and adding the -fcommon flag for all calls made the deployment go past compilation. Since this is a change needed on various release packages and adding -fcommon solved it globally I'm assuming that adding that particular flag to all affected packages should solve the issue when releases are upgrading to the new stemcell.