### PR TITLE
Drop dracut and switch to default initramfs tools

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-bionic.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-bionic.txt
@@ -52,8 +52,6 @@ dmsetup
 dnsutils
 dpkg
 dpkg-dev
-dracut
-dracut-core
 e2fsprogs
 eject
 fdisk

--- a/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
@@ -40,12 +40,6 @@ describe 'Ubuntu 18.04 OS image', os_image: true do
     end
   end
 
-  context 'installed by system_kernel' do
-    describe file('/etc/dracut.conf.d/10-debian.conf') do
-      its(:content) { should_not match '^add_drivers.*' }
-    end
-  end
-
   describe 'base_apt' do
     describe file('/etc/apt/sources.list') do
       its(:content) { should match 'deb http://archive.ubuntu.com/ubuntu bionic main universe multiverse' }

--- a/stemcell_builder/stages/base_apt/apply.sh
+++ b/stemcell_builder/stages/base_apt/apply.sh
@@ -17,10 +17,6 @@ EOS
 # Upgrade systemd/upstart first, to prevent it from messing up our stubs and starting daemons anyway
 pkg_mgr install systemd
 
-# Normalize initramfs so that all distos can use dracut
-pkg_mgr purge busybox-initramfs
-pkg_mgr install dracut
-
 pkg_mgr dist-upgrade
 
 # initscripts messes with /dev/shm -> /run/shm and can create self-referencing symbolic links

--- a/stemcell_builder/stages/system_kernel/apply.sh
+++ b/stemcell_builder/stages/system_kernel/apply.sh
@@ -11,8 +11,6 @@ mkdir -p $chroot/tmp
 
 
 if [[  "${DISTRIB_CODENAME}" == "bionic" ]]; then
-  # remove additional drivers like crc32c kernel module.
-  sed -i "/^add_drivers.*/d" $chroot/etc/dracut.conf.d/10-debian.conf
   pkg_mgr install linux-generic-hwe-18.04
 elif [[  "${DISTRIB_CODENAME}" == "jammy" ]]; then
   sed -i "/^add_drivers.*/d" $chroot/etc/dracut.conf.d/10-debian.conf


### PR DESCRIPTION
From what I can see, dracut was used to normalize initramfs creation
for all distros. But it seems since commit 6acd0c9cf71ed that only
Ubuntu is left.
So switch to the default initramfs tools for creating the initial
ramdisk.
This has multiple advantages:
- initramfs tools is the default way on Ubuntu for creating initial
  ramdisk. That means that it's in the "main" component which is
  supported by the Ubuntu security team[1]. dracut is in universe
  which is not supported by the Ubuntu security team.
- the Ubuntu FIPS[0] packages can depend on initramfs tools. So
  installing those FIPS packages does not work with dracut.

[0] https://ubuntu.com/security/certifications/docs
[1] https://wiki.ubuntu.com/SecurityTeam/FAQ