### PR TITLE
Add stage to build a Ubuntu Bionic FIPS stemcell

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
@@ -62,6 +62,7 @@ module Bosh::Stemcell
       {
         'UBUNTU_ISO' => environment['UBUNTU_ISO'],
         'UBUNTU_MIRROR' => environment['UBUNTU_MIRROR'],
+        'UBUNTU_ADVANTAGE_TOKEN' => environment['UBUNTU_ADVANTAGE_TOKEN'],
       }
     end
 

--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -249,6 +249,7 @@ module Bosh::Stemcell
         :base_debootstrap,
         :base_ubuntu_firstboot,
         :base_apt,
+        :base_apt_fips,
         :base_ubuntu_build_essential,
         :base_ubuntu_packages,
         :base_file_permission,

--- a/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_bionic_spec.rb
@@ -35,8 +35,10 @@ describe 'Ubuntu 18.04 OS image', os_image: true do
   end
 
   context 'installed by system_kernel' do
-    describe package('linux-generic-hwe-18.04') do
-      it { should be_installed }
+    if ENV.key?("UBUNTU_ADVANTAGE_TOKEN")
+      kernel_pkg_name = 'linux-aws-fips'
+    else
+      kernel_pkg_name = 'linux-generic-hwe-18.04'
     end
   end
 
@@ -86,15 +88,24 @@ describe 'Ubuntu 18.04 OS image', os_image: true do
       expect(sshd_config.content).to match(/^Ciphers #{ciphers}$/)
     end
 
-    it 'allows only secure HMACs and the weaker SHA1 HMAC required by golang ssh lib' do
-      macs = %w[
-        hmac-sha2-512-etm@openssh.com
-        hmac-sha2-256-etm@openssh.com
-        umac-128-etm@openssh.com
-        hmac-sha2-512
-        hmac-sha2-256
-        umac-128@openssh.com
+    it 'allows only secure HMACs' do
+      if ENV.key?("UBUNTU_ADVANTAGE_TOKEN")
+        macs = %w[
+          hmac-sha2-512-etm@openssh.com
+          hmac-sha2-256-etm@openssh.com
+          hmac-sha2-512
+          hmac-sha2-256
       ].join(',')
+      else
+        macs = %w[
+          hmac-sha2-512-etm@openssh.com
+          hmac-sha2-256-etm@openssh.com
+          umac-128-etm@openssh.com
+          hmac-sha2-512
+          hmac-sha2-256
+          umac-128@openssh.com
+      ].join(',')
+      end
       expect(sshd_config.content).to match(/^MACs #{macs}$/)
     end
   end
@@ -360,7 +371,38 @@ EOF
 
   describe 'allowed user accounts' do
     describe file('/etc/passwd') do
-      its(:content) { should eql(<<HERE) }
+      if ENV.key?("UBUNTU_ADVANTAGE_TOKEN")
+        its(:content) { should eql(<<HERE) }
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+systemd-network:x:100:102:systemd Network Management,,,:/run/systemd/netif:/usr/sbin/nologin
+systemd-resolve:x:101:103:systemd Resolver,,,:/run/systemd/resolve:/usr/sbin/nologin
+syslog:x:102:106::/home/syslog:/usr/sbin/nologin
+messagebus:x:103:107::/nonexistent:/usr/sbin/nologin
+_apt:x:104:65534::/nonexistent:/usr/sbin/nologin
+sshd:x:105:65534::/run/sshd:/usr/sbin/nologin
+uuidd:x:106:110::/run/uuidd:/usr/sbin/nologin
+_chrony:x:107:111:Chrony daemon,,,:/var/lib/chrony:/usr/sbin/nologin
+vcap:x:1000:1000:BOSH System User:/home/vcap:/bin/bash
+HERE
+      else
+        its(:content) { should eql(<<HERE) }
 root:x:0:0:root:/root:/bin/bash
 daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
 bin:x:2:2:bin:/bin:/usr/sbin/nologin
@@ -389,10 +431,42 @@ _chrony:x:106:110:Chrony daemon,,,:/var/lib/chrony:/usr/sbin/nologin
 sshd:x:107:65534::/run/sshd:/usr/sbin/nologin
 vcap:x:1000:1000:BOSH System User:/home/vcap:/bin/bash
 HERE
+      end
     end
 
     describe file('/etc/shadow') do
-      shadow_match = Regexp.new <<'END_SHADOW', [Regexp::MULTILINE]
+      if ENV.key?("UBUNTU_ADVANTAGE_TOKEN")
+        shadow_match = Regexp.new <<'END_SHADOW', [Regexp::MULTILINE]
+\Aroot:(.+):(\d{5}):0:99999:7:::
+daemon:\*:(\d{5}):0:99999:7:::
+bin:\*:(\d{5}):0:99999:7:::
+sys:\*:(\d{5}):0:99999:7:::
+sync:\*:(\d{5}):0:99999:7:::
+games:\*:(\d{5}):0:99999:7:::
+man:\*:(\d{5}):0:99999:7:::
+lp:\*:(\d{5}):0:99999:7:::
+mail:\*:(\d{5}):0:99999:7:::
+news:\*:(\d{5}):0:99999:7:::
+uucp:\*:(\d{5}):0:99999:7:::
+proxy:\*:(\d{5}):0:99999:7:::
+www-data:\*:(\d{5}):0:99999:7:::
+backup:\*:(\d{5}):0:99999:7:::
+list:\*:(\d{5}):0:99999:7:::
+irc:\*:(\d{5}):0:99999:7:::
+gnats:\*:(\d{5}):0:99999:7:::
+nobody:\*:(\d{5}):0:99999:7:::
+systemd-network:\*:(\d{5}):0:99999:7:::
+systemd-resolve:\*:(\d{5}):0:99999:7:::
+syslog:\*:(\d{5}):0:99999:7:::
+messagebus:\*:(\d{5}):0:99999:7:::
+_apt:\*:(\d{5}):0:99999:7:::
+sshd:\*:(\d{5}):0:99999:7:::
+uuidd:(.+):(\d{5}):0:99999:7:::
+_chrony:(.+):(\d{5}):0:99999:7:::
+vcap:(.+):(\d{5}):1:99999:7:::\Z
+END_SHADOW
+      else
+        shadow_match = Regexp.new <<'END_SHADOW', [Regexp::MULTILINE]
 \Aroot:(.+):(\d{5}):0:99999:7:::
 daemon:\*:(\d{5}):0:99999:7:::
 bin:\*:(\d{5}):0:99999:7:::
@@ -421,12 +495,70 @@ _chrony:(.+):(\d{5}):0:99999:7:::
 sshd:\*:(\d{5}):0:99999:7:::
 vcap:(.+):(\d{5}):1:99999:7:::\Z
 END_SHADOW
-
+      end
       its(:content) { should match(shadow_match) }
     end
 
     describe file('/etc/group') do
-      its(:content) { should eql(<<HERE) }
+      if ENV.key?("UBUNTU_ADVANTAGE_TOKEN")
+        its(:content) { should eql(<<HERE) }
+root:x:0:
+daemon:x:1:
+bin:x:2:
+sys:x:3:
+adm:x:4:vcap
+tty:x:5:
+disk:x:6:
+lp:x:7:
+mail:x:8:
+news:x:9:
+uucp:x:10:
+man:x:12:
+proxy:x:13:
+kmem:x:15:
+dialout:x:20:vcap
+fax:x:21:
+voice:x:22:
+cdrom:x:24:vcap
+floppy:x:25:vcap
+tape:x:26:
+sudo:x:27:vcap
+audio:x:29:vcap
+dip:x:30:vcap
+www-data:x:33:
+backup:x:34:
+operator:x:37:
+list:x:38:
+irc:x:39:
+src:x:40:
+gnats:x:41:
+shadow:x:42:
+utmp:x:43:
+video:x:44:vcap
+sasl:x:45:
+plugdev:x:46:vcap
+staff:x:50:
+games:x:60:
+users:x:100:
+nogroup:x:65534:
+systemd-journal:x:101:
+systemd-network:x:102:
+systemd-resolve:x:103:
+input:x:104:
+crontab:x:105:
+syslog:x:106:
+messagebus:x:107:
+ssh:x:108:
+netdev:x:109:
+uuidd:x:110:
+_chrony:x:111:
+admin:x:999:vcap
+vcap:x:1000:syslog
+bosh_sshers:x:1001:vcap
+bosh_sudoers:x:1002:
+HERE
+      else
+                its(:content) { should eql(<<HERE) }
 root:x:0:
 daemon:x:1:
 bin:x:2:
@@ -482,10 +614,69 @@ vcap:x:1000:syslog
 bosh_sshers:x:1001:vcap
 bosh_sudoers:x:1002:
 HERE
+      end
     end
 
     describe file('/etc/gshadow') do
-      its(:content) { should eql(<<HERE) }
+      if ENV.key?("UBUNTU_ADVANTAGE_TOKEN")
+        its(:content) { should eql(<<HERE) }
+root:*::
+daemon:*::
+bin:*::
+sys:*::
+adm:*::vcap
+tty:*::
+disk:*::
+lp:*::
+mail:*::
+news:*::
+uucp:*::
+man:*::
+proxy:*::
+kmem:*::
+dialout:*::vcap
+fax:*::
+voice:*::
+cdrom:*::vcap
+floppy:*::vcap
+tape:*::
+sudo:*::vcap
+audio:*::vcap
+dip:*::vcap
+www-data:*::
+backup:*::
+operator:*::
+list:*::
+irc:*::
+src:*::
+gnats:*::
+shadow:*::
+utmp:*::
+video:*::vcap
+sasl:*::
+plugdev:*::vcap
+staff:*::
+games:*::
+users:*::
+nogroup:*::
+systemd-journal:!::
+systemd-network:!::
+systemd-resolve:!::
+input:!::
+crontab:!::
+syslog:!::
+messagebus:!::
+ssh:!::
+netdev:!::
+uuidd:!::
+_chrony:!::
+admin:!::vcap
+vcap:!::syslog
+bosh_sshers:!::vcap
+bosh_sudoers:!::
+HERE
+      else
+        its(:content) { should eql(<<HERE) }
 root:*::
 daemon:*::
 bin:*::
@@ -541,6 +732,7 @@ vcap:!::syslog
 bosh_sshers:!::vcap
 bosh_sudoers:!::
 HERE
+      end
     end
   end
 end

--- a/stemcell_builder/stages/base_apt_fips/apply.sh
+++ b/stemcell_builder/stages/base_apt_fips/apply.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/etc/settings.bash
+
+# do nothing if the variant isn't fips
+if [ ${stemcell_operating_system_variant} != "fips" ]; then
+    echo "Skipping base_apt_fips given that this is not a 'fips' variant"
+    exit 0
+else
+    echo "FIPS variant detected. setting up FIPS"
+fi
+
+
+if [ -z ${UBUNTU_ADVANTAGE_TOKEN} ]; then
+    echo "'fips' variant detected but \$UBUNTU_ADVANTAGE_TOKEN not given."
+    echo "please provide a UBUNTU_ADVANTAGE_TOKEN to be able to build 'fips' variants."
+    exit 1
+fi
+
+
+function ua_attach() {
+    local chroot=$1
+    DEBIAN_FRONTEND=noninteractive run_in_chroot ${chroot} "apt-get install --assume-yes ubuntu-advantage-tools"
+
+    # overwrite the cloud type so the correct kernel gets installed
+    # FIXME: do not hardcode aws here!
+    echo "settings_overrides:" >> ${chroot}/etc/ubuntu-advantage/uaclient.conf
+    echo "  cloud_type: aws" >> ${chroot}/etc/ubuntu-advantage/uaclient.conf
+    run_in_chroot ${chroot} "ua attach --no-auto-enable ${UBUNTU_ADVANTAGE_TOKEN}"
+}
+
+
+function ua_detach() {
+    local chroot=$1
+    run_in_chroot ${chroot} "ua detach --assume-yes"
+    # cleanup (to not leak the token into an image)
+    run_in_chroot ${chroot} "rm -rf /var/lib/ubuntu-advantage/private/*"
+    run_in_chroot ${chroot} "rm /var/log/ubuntu-advantage.log"
+}
+
+
+function ua_enable_fips() {
+    local chroot=$1
+    run_in_chroot ${chroot} "ua enable --assume-yes fips"
+}
+
+
+function install_and_hold_packages() {
+    local chroot=$1
+    local pkgs=$2
+    echo "Installing and holding packages: ${pkgs}"
+    DEBIAN_FRONTEND=noninteractive run_in_chroot ${chroot} "apt-get install --assume-yes ${pkgs}"
+
+    # NOTE:This package hold creates problems for users wanting to install
+    # updates from the FIPS update PPA. However this hold is required
+    # until there is a FIPS meta-package which can ensure higher versioned,
+    # non-FIPS packages are not selected to replace these.
+    DEBIAN_FRONTEND=noninteractive run_in_chroot ${chroot} "apt-mark hold ${pkgs}"
+}
+
+
+# taken from https://git.launchpad.net/livecd-rootfs/tree/live-build/ubuntu-cpc/hooks.d/chroot/999-cpc-fixes.chroot#n125
+psuedo_grub_probe() {
+   cat <<"PSUEDO_GRUB_PROBE"
+#!/bin/sh
+Usage() {
+   cat <<EOF
+Usage: euca-psuedo-grub-probe
+   this is a wrapper around grub-probe to provide the answers for an ec2 guest
+EOF
+}
+bad_Usage() { Usage 1>&2; fail "$@"; }
+
+short_opts=""
+long_opts="device-map:,target:,device"
+getopt_out=$(getopt --name "${0##*/}" \
+   --options "${short_opts}" --long "${long_opts}" -- "$@") &&
+   eval set -- "${getopt_out}" ||
+   bad_Usage
+
+device_map=""
+target=""
+device=0
+arg=""
+
+while [ $# -ne 0 ]; do
+   cur=${1}; next=${2};
+   case "$cur" in
+      --device-map) device_map=${next}; shift;;
+      --device) device=1;;
+      --target) target=${next}; shift;;
+      --) shift; break;;
+   esac
+   shift;
+done
+arg=${1}
+
+case "${target}:${device}:${arg}" in
+   device:*:/*) echo "/dev/sda1"; exit 0;;
+   fs:*:*) echo "ext2"; exit 0;;
+   partmap:*:*)
+      # older versions of grub (lucid) want 'part_msdos' written
+      # rather than 'msdos'
+      legacy_pre=""
+      grubver=$(dpkg-query --show --showformat '${Version}\n' grub-pc 2>/dev/null) &&
+         dpkg --compare-versions "${grubver}" lt 1.98+20100804-5ubuntu3 &&
+         legacy_pre="part_"
+      echo "${legacy_pre}msdos";
+      exit 0;;
+   abstraction:*:*) echo ""; exit 0;;
+   drive:*:/dev/sda) echo "(hd0)";;
+   drive:*:/dev/sda*) echo "(hd0,1)";;
+   fs_uuid:*:*) exit 1;;
+esac
+PSUEDO_GRUB_PROBE
+}
+
+
+function mock_grub_probe() {
+    local chroot=$1
+    # make sure /usr/sbin/grub-probe is installed in the chroot
+    DEBIAN_FRONTEND=noninteractive run_in_chroot ${chroot} "apt-get install --assume-yes grub-common"
+    gprobe="${chroot}/usr/sbin/grub-probe"
+    if [ -f "${gprobe}" ]; then
+	mv "${gprobe}" "${gprobe}.dist"
+    fi
+    psuedo_grub_probe > "${gprobe}"
+    chmod 755 "${gprobe}"
+}
+
+
+function unmock_grub_probe() {
+    local chroot=$1
+    gprobe="${chroot}/usr/sbin/grub-probe"
+    if [ -f "${gprobe}.dist" ]; then
+	mv "${gprobe}.dist" "${gprobe}"
+    fi
+}
+
+# those packages need to be installed from the FIPS repo and hold
+FIPS_PKGS="openssh-client openssh-server openssl libssl1.1 libssl1.1-hmac libssl-dev fips-initramfs libgcrypt20 libgcrypt20-hmac libgcrypt20-dev linux-image-aws-fips linux-aws-fips linux-headers-aws-fips fips-initramfs linux-modules-extra-4.15.0-2000-aws-fips"
+
+echo "Setting up Ubuntu Advantage ..."
+
+mock_grub_probe "${chroot}"
+ua_attach "${chroot}"
+ua_enable_fips "${chroot}"
+install_and_hold_packages "${chroot}" "${FIPS_PKGS}"
+ua_detach "${chroot}"
+
+unmock_grub_probe "${chroot}"

--- a/stemcell_builder/stages/base_apt_fips/config.sh
+++ b/stemcell_builder/stages/base_apt_fips/config.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_config.bash
+
+persist stemcell_operating_system_variant
+persist UBUNTU_ADVANTAGE_TOKEN

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -4,6 +4,7 @@ set -e
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
+source $base_dir/etc/settings.bash
 
 chmod 0600 $chroot/etc/ssh/sshd_config
 
@@ -76,7 +77,13 @@ echo 'Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ct
 
 # Disallow Weak MACs
 sed "/^ *MACs/d" -i $chroot/etc/ssh/sshd_config
-echo 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com' >> $chroot/etc/ssh/sshd_config
+if [ -z ${UBUNTU_ADVANTAGE_TOKEN+x} ]; then
+    echo 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com' >> $chroot/etc/ssh/sshd_config
+else
+    # FIPS only allows specific MACs. See "Security Policy" from
+    # https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3632
+    echo 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256' >> $chroot/etc/ssh/sshd_config
+fi
 
 cat << EOF > $chroot/etc/issue
 Unauthorized use is strictly prohibited. All access and activity

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -4,6 +4,7 @@ set -e
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
+source $base_dir/etc/settings.bash
 
 debs="libssl-dev lsof strace bind9-host dnsutils tcpdump iputils-arping \
 curl wget bison libreadline6-dev rng-tools \
@@ -77,8 +78,13 @@ run_in_chroot "${chroot}" "systemctl enable runit"
 run_in_chroot "${chroot}" "systemctl enable systemd-logind"
 run_in_chroot "${chroot}" "systemctl enable systemd-networkd"
 run_in_chroot "${chroot}" "systemctl disable systemd-resolved"
-pkgs_to_purge="crda iw mg wireless-crda wireless-regdb"
-pkg_mgr purge --auto-remove "$pkgs_to_purge"
+
+# FIPS kernel depends on crda so do not try to remove it
+if [ -z ${UBUNTU_ADVANTAGE_TOKEN+x} ]; then
+    pkgs_to_purge="crda iw mg wireless-crda wireless-regdb"
+    pkg_mgr purge --auto-remove "$pkgs_to_purge"
+fi
+
 run_in_chroot "${chroot}" "systemctl disable chrony"
 
 exclusions="postfix whoopsie apport"

--- a/stemcell_builder/stages/static_libraries_config/apply.sh
+++ b/stemcell_builder/stages/static_libraries_config/apply.sh
@@ -5,14 +5,22 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
+source $base_dir/etc/settings.bash
 
 cp -p "${assets_dir}/${DISTRIB_CODENAME}_static_libraries_list.txt" $chroot/var/vcap/bosh/etc/static_libraries_list
 
 
+kernel_suffix="-generic"
 if [[ "${DISTRIB_CODENAME}" == 'bionic' ]]; then
-    major_kernel_version="5.4"
+    if [ -z ${UBUNTU_ADVANTAGE_TOKEN+x} ]; then
+	major_kernel_version="5.4"
+    else
+	# FIPS kernel is 4.15
+	major_kernel_version="4.15"
+	kernel_suffix="-aws-fips"
+    fi
 else
     major_kernel_version="4.15"
 fi
-kernel_version=$(find $chroot/usr/src/ -name "linux-headers-$major_kernel_version.*-generic" | grep -o '[0-9].*-[0-9]*-generic')
+kernel_version=$(find $chroot/usr/src/ -name "linux-headers-$major_kernel_version.*$kernel_suffix" | grep -o "[0-9].*-[0-9]*$kernel_suffix")
 sed -i "s/__KERNEL_VERSION__/$kernel_version/g" $chroot/var/vcap/bosh/etc/static_libraries_list

--- a/stemcell_builder/stages/system_kernel/apply.sh
+++ b/stemcell_builder/stages/system_kernel/apply.sh
@@ -5,7 +5,13 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
+source $base_dir/etc/settings.bash
 
+
+if [ ! -z ${UBUNTU_ADVANTAGE_TOKEN+x} ]; then
+    echo "Ubuntu Advantage used. Skipping system_kernel setup"
+    exit 0
+fi
 
 mkdir -p $chroot/tmp
 


### PR DESCRIPTION
There are usecases where FIPS compliant stemcells are needed. So
adding an option to be able to build FIPS compliant stemcells here.

Note: The implementation depends on the Operating system variant and the UBUNTU_ADVANTAGE_TOKEN
environment variable. If the variant is `fips` and the env variable is set (it needs to be a valid
token because it's later used by the ubuntu-advantage tool to install
the relevant FIPS packages), the build will produce a FIPS stemcell.