### PR TITLE
Fix syntax errors in networking post-start scripts

### DIFF
--- a/stemcell_builder/stages/bosh_go_agent/assets/02-restrict-nats-api-access-allow-monit-api
+++ b/stemcell_builder/stages/bosh_go_agent/assets/02-restrict-nats-api-access-allow-monit-api
@@ -7,6 +7,7 @@ source /var/vcap/bosh/etc/nats-access-helper.sh
 # Give the agent access to Monit right away
 if ! iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
             -m cgroup --cgroup "${nats_isolation_classid}" -j ACCEPT
+then
     iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
              -m cgroup --cgroup "${nats_isolation_classid}" -j ACCEPT
 fi
@@ -27,7 +28,7 @@ wait_for_agent_settings() {
     # GET SECOND FIELD WITH DELIMITER `@` LEAVING `IP:PORT`
     BOSH_IP_PORT=$( cut -f2 -d@ <<< "${NATS_URL}" )
     # GET FIRST FIELD WITH DELIMITER `:` LEAVING `IP`
-    BOSH_IP=$( cut -f1 -d: <<< "${BOSH_IP_PORT} )"
+    BOSH_IP=$( cut -f1 -d: <<< "${BOSH_IP_PORT}" )
     # GET SECOND FIELD WITH DELIMITER `:` LEAVING `PORT`
     BOSH_PORT=$( cut -f2 -d: <<< "${BOSH_IP_PORT}" )
 

--- a/stemcell_builder/stages/bosh_monit/assets/01-restrict-monit-api-access
+++ b/stemcell_builder/stages/bosh_monit/assets/01-restrict-monit-api-access
@@ -4,6 +4,7 @@ source /var/vcap/bosh/etc/monit-access-helper.sh
 
 if ! iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
 	    -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
+then
     iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
 	     -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
 fi


### PR DESCRIPTION
- Missing 'then's and incorrect quotes caused networking service to
  report a failed state.
- Also meant that intended iptables rules to block traffic to nats and
  monit processes were not applied.

Signed-off-by: Rajan Agaskar <ragaskar@vmware.com>