### PR TITLE
Install netcat-openbsd explicitly

### DIFF
--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -14,7 +14,8 @@ libaio1 gdb libcap2-bin libcap2-dev libbz2-dev \
 cmake uuid-dev libgcrypt-dev ca-certificates \
 scsitools mg htop module-assistant debhelper runit parted \
 cloud-guest-utils anacron software-properties-common \
-xfsprogs gdisk libpam-cracklib chrony module-init-tools dbus nvme-cli rng-tools"
+xfsprogs gdisk libpam-cracklib chrony module-init-tools dbus nvme-cli rng-tools \
+netcat-openbsd"
 
 if [[ "${DISTRIB_CODENAME}" == 'xenial' ]]; then
   debs="$debs  libcurl3 libcurl3-dev"


### PR DESCRIPTION
netcat-openbsd is needed (see content of
bosh-stemcell/spec/assets/dpkg-list-ubuntu-bionic.txt) so install it
explicitly.
This fixes a problem when using Ubuntu FIPS packages where
netcat-openbsd is not automatically installed.