### PR TITLE
Add support for building stemcell variants

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
@@ -183,7 +183,7 @@ module Bosh::Stemcell
       else
         nil
       end,
-      unless operating_system.variant.nil?
+      if operating_system.variant?
         " --tag #{operating_system.variant}"
       end,
       ].compact.join(' ').rstrip

--- a/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
@@ -181,9 +181,12 @@ module Bosh::Stemcell
       when 'google'
         ' --tag ~exclude_on_google'
       else
-        ''
+        nil
       end,
-      ].join(' ').rstrip
+      unless operating_system.variant.nil?
+        " --tag #{operating_system.variant}"
+      end,
+      ].compact.join(' ').rstrip
     end
 
     def image_file_path

--- a/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
@@ -23,6 +23,7 @@ module Bosh::Stemcell
         'stemcell_infrastructure' => infrastructure.name,
         'stemcell_operating_system' => operating_system.name,
         'stemcell_operating_system_version' => operating_system.version,
+        'stemcell_operating_system_variant' => operating_system.variant,
         'ruby_bin' => ruby_bin,
         'image_create_disk_size' => image_create_disk_size,
         'os_image_tgz' => os_image_tgz_path,

--- a/bosh-stemcell/lib/bosh/stemcell/definition.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/definition.rb
@@ -26,6 +26,7 @@ module Bosh::Stemcell
         operating_system.name,
       ]
       stemcell_name_parts << operating_system.version if operating_system.version
+      stemcell_name_parts << operating_system.variant if operating_system.variant
       stemcell_name_parts << 'go_agent'
       stemcell_name_parts << disk_format unless disk_format == infrastructure.default_disk_format
 

--- a/bosh-stemcell/lib/bosh/stemcell/operating_system.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/operating_system.rb
@@ -10,6 +10,7 @@ module Bosh::Stemcell
 
     class Base
       attr_reader :name, :version, :variant
+      alias_method :variant?, :variant
 
       def initialize(options = {})
         @name = options.fetch(:name)
@@ -24,7 +25,7 @@ module Bosh::Stemcell
 
     class Ubuntu < Base
       def initialize(version)
-        (version, variant) = version.split('-') unless version.nil?
+        (version, variant) = version.split('-') if version
         super(name: 'ubuntu', version: version, variant: variant)
       end
     end

--- a/bosh-stemcell/lib/bosh/stemcell/operating_system.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/operating_system.rb
@@ -9,11 +9,12 @@ module Bosh::Stemcell
     end
 
     class Base
-      attr_reader :name, :version
+      attr_reader :name, :version, :variant
 
       def initialize(options = {})
         @name = options.fetch(:name)
         @version = options.fetch(:version)
+        @variant = options.fetch(:variant, nil)
       end
 
       def ==(other)
@@ -23,7 +24,8 @@ module Bosh::Stemcell
 
     class Ubuntu < Base
       def initialize(version)
-        super(name: 'ubuntu', version: version)
+        (version, variant) = version.split('-') unless version.nil?
+        super(name: 'ubuntu', version: version, variant: variant)
       end
     end
   end

--- a/bosh-stemcell/lib/bosh/stemcell/stemcell_packager.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stemcell_packager.rb
@@ -44,7 +44,7 @@ module Bosh
           'bosh_protocol' => 1,
           'api_version' => 3,
           'sha1' => image_checksum,
-          'operating_system' => "#{definition.operating_system.name}-#{definition.operating_system.version}",
+          'operating_system' => manifest_operating_system,
           'stemcell_formats' => infrastructure.stemcell_formats,
           'cloud_properties' => manifest_cloud_properties(disk_format, infrastructure, stemcell_name)
         }
@@ -65,6 +65,14 @@ module Bosh
             'os_distro' => definition.operating_system.name,
             'architecture' => architecture,
         }.merge(infrastructure.additional_cloud_properties)
+      end
+
+      def manifest_operating_system
+        # compact because variant can be nill
+        [ definition.operating_system.name,
+          definition.operating_system.version,
+          definition.operating_system.variant,
+        ].compact.join('-')
       end
 
       def create_tarball(disk_format)

--- a/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
@@ -196,6 +196,7 @@ module Bosh::Stemcell
 
     describe '#stemcell_rspec_command' do
       before { allow(operating_system).to receive(:version).and_return('fake-version') }
+      before { allow(operating_system).to receive(:variant).and_return('fips') }
 
       it 'returns the correct command' do
         expected_rspec_command = [
@@ -205,7 +206,7 @@ module Bosh::Stemcell
           "OS_NAME=#{operating_system.name}",
           "OS_VERSION=#{operating_system.version}",
           "CANDIDATE_BUILD_NUMBER=#{version}",
-          "bundle exec rspec -fd",
+          "bundle exec rspec -fd --tag fips",
           "spec/os_image/#{operating_system.name}_#{operating_system.version}_spec.rb",
           "spec/stemcells/#{operating_system.name}_#{operating_system.version}_spec.rb",
           "spec/stemcells/go_agent_spec.rb",

--- a/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
@@ -196,6 +196,7 @@ module Bosh::Stemcell
 
     describe '#stemcell_rspec_command' do
       before { allow(operating_system).to receive(:version).and_return('fake-version') }
+      before { allow(operating_system).to receive(:variant?).and_return(true) }
       before { allow(operating_system).to receive(:variant).and_return('fips') }
 
       it 'returns the correct command' do

--- a/bosh-stemcell/spec/bosh/stemcell/builder_options_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/builder_options_spec.rb
@@ -25,7 +25,7 @@ module Bosh::Stemcell
     }
 
     let(:infrastructure) { Infrastructure.for('aws') }
-    let(:operating_system) { OperatingSystem.for('ubuntu', 'penguin') }
+    let(:operating_system) { OperatingSystem.for('ubuntu', 'penguin-bear') }
     let(:expected_source_root) { File.expand_path('../../../../..', __FILE__) }
     let(:archive_filename) { instance_double('Bosh::Stemcell::ArchiveFilename', to_s: 'FAKE_STEMCELL.tgz') }
 
@@ -51,6 +51,11 @@ module Bosh::Stemcell
       it 'sets stemcell operating system version' do
         result = stemcell_builder_options.default
         expect(result['stemcell_operating_system_version']).to eq('penguin')
+      end
+
+      it 'sets stemcell operating system variant' do
+        result = stemcell_builder_options.default
+        expect(result['stemcell_operating_system_variant']).to eq('bear')
       end
 
       # rubocop:disable MethodLength

--- a/bosh-stemcell/spec/bosh/stemcell/definition_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/definition_spec.rb
@@ -16,11 +16,13 @@ module Bosh::Stemcell
 
     let(:hypervisor) { "hypervisor" }
     let(:operating_system_version) { 'operating_system_version' }
+    let(:operating_system_variant) { nil }
     let(:operating_system) do
       instance_double(
         'Bosh::Stemcell::OperatingSystem::Base',
         name: 'operating-system-name',
         version: operating_system_version,
+        variant: operating_system_variant,
       )
     end
 
@@ -90,6 +92,16 @@ module Bosh::Stemcell
         it 'leaves off the os version' do
           expect(definition.stemcell_name('disk-format')).to eq(
             'infrastructure-name-hypervisor-operating-system-name-go_agent-disk-format'
+          )
+        end
+      end
+
+      context 'the os has a variant' do
+        let(:operating_system_variant) { 'variant' }
+
+        it 'leaves off the os version' do
+          expect(definition.stemcell_name('disk-format')).to eq(
+            'infrastructure-name-hypervisor-operating-system-name-operating_system_version-variant-go_agent-disk-format'
           )
         end
       end

--- a/bosh-stemcell/spec/bosh/stemcell/operating_system_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/operating_system_spec.rb
@@ -42,13 +42,20 @@ module Bosh::Stemcell
 
       its(:version) { should eq('HORSESHOE') }
     end
+
+    describe '#variant' do
+      subject { OperatingSystem::Base.new(name: 'CLOUDY_PONY_OS', version: 'HORSESHOE', variant: 'DONKYTAIL') }
+
+      its(:variant) { should eq('DONKYTAIL') }
+    end
   end
 
   describe OperatingSystem::Ubuntu do
-    subject { OperatingSystem::Ubuntu.new('penguin') }
+    subject { OperatingSystem::Ubuntu.new('penguin-gentoo') }
 
     its(:name) { should eq('ubuntu') }
     its(:version) { should eq('penguin') }
-    it { should eq OperatingSystem.for('ubuntu', 'penguin') }
+    its(:variant) { should eq('gentoo') }
+    it { should eq OperatingSystem.for('ubuntu', 'penguin-gentoo') }
   end
 end

--- a/bosh-stemcell/spec/bosh/stemcell/stemcell_packager_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stemcell_packager_spec.rb
@@ -197,5 +197,23 @@ image
         expect(File.exist?(tarball_path)).to eq(true)
       end
     end
+
+    context 'when packaging a non standard os variant' do
+      let(:operating_system) { Bosh::Stemcell::OperatingSystem.for('ubuntu', 'bionic-fips') }
+
+      it 'archives the working dir with a different tarball name' do
+        packager.package(disk_format)
+        tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-bionic-fips-go_agent.tgz")
+        expect(File.exist?(tarball_path)).to eq(true)
+      end
+
+      it 'writes the variant into the stemcell.MF' do
+        packager.package('raw')
+
+        actual_manifest = YAML.load_file(File.join(work_dir, 'stemcell/stemcell.MF'))
+
+        expect(actual_manifest['operating_system']).to eq('ubuntu-bionic-fips')
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is an providing a framwork to be used by the fips PR: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/210.

To build a variant suffix the version with -{variant_name} example:
```
bundle exec rake stemcell:build_os_image[ubuntu,bionic-fips,$PWD/tmp/ubuntu_base_image.tg]
```

The variant will also be passed to rspec as a tag which can be used to run specific tests only when building a variant.
