### PR TITLE
Bugfix/azure broken ssh

### DIFF
--- a/stemcell_builder/stages/system_azure_wala/assets/etc/waagent.conf
+++ b/stemcell_builder/stages/system_azure_wala/assets/etc/waagent.conf
@@ -15,7 +15,7 @@ Provisioning.Agent=waagent   # NON-DEFAULT, the BOSH agent takes this place
 Provisioning.DeleteRootPassword=n  # NON-DEFAULT, already in stemcell
 
 # Generate fresh host key pair.
-Provisioning.RegenerateSshHostKeyPair=y
+Provisioning.RegenerateSshHostKeyPair=n
 
 # Supported values are "rsa", "dsa", "ecdsa", "ed25519", and "auto".
 # The "auto" option is supported on OpenSSH 5.9 (2011) and later.

--- a/stemcell_builder/stages/system_azure_wala/assets/etc/walinuxagent.service
+++ b/stemcell_builder/stages/system_azure_wala/assets/etc/walinuxagent.service
@@ -15,6 +15,9 @@ ConditionPathExists=/etc/waagent.conf
 
 [Service]
 Type=simple
+# stemcells on Azure re-generate the SSH Hostkey upon first reboot
+# waagent has to wait until the file was recreated
+ExecStartPre=/bin/bash -c "while [ ! -f /root/firstboot_done ]; do sleep 1; done"
 ExecStart=/usr/bin/python3 -u /usr/sbin/waagent -daemon
 Restart=always
 Slice=azure.slice


### PR DESCRIPTION
jammy counterpart to https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/232

currenlty azure waagent regenerates the host keys as well as the
firstboot.sh
via:
```
rm -f /etc/ssh/ssh_host*key*

dpkg-reconfigure -fnoninteractive -pcritical openssh-server
```

this breaks bosh ssh because, sometimes, on boot the dpkg-reconfigure is stuck on
some VMs following what I assume is a race condition between waagent and firstboot. 
The result is that the firstboot script gets stuck and leads to a stopped systemd ssh.service :

ps ax from a broken vm:

```
   1268 ?        S      0:00 /usr/bin/perl -w /usr/sbin/dpkg-reconfigure -fnoninteractive -pcritical openssh-server
   1362 ?        S      0:00 /bin/sh /var/lib/dpkg/info/openssh-server.postinst configure 1:8.9p1-3
```

after manually starting the ssh service on the VM (via azure RunCommand feature) bosh ssh is starting to work again.
