### PR TITLE
Enable FIPS mode for bionic-fips stemcells

### DIFF
--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -57,6 +57,11 @@ function install_and_hold_packages() {
 }
 
 
+function write_fips_cmdline_conf() {
+    run_in_chroot ${chroot} "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"$GRUB_CMDLINE_LINUX_DEFAULT fips=1\"' > /etc/default/grub.d/99-fips.cfg"
+}
+
+
 # taken from https://git.launchpad.net/livecd-rootfs/tree/live-build/ubuntu-cpc/hooks.d/chroot/999-cpc-fixes.chroot#n125
 psuedo_grub_probe() {
    cat <<"PSUEDO_GRUB_PROBE"

--- a/stemcell_builder/stages/base_fips_apt/apply.sh
+++ b/stemcell_builder/stages/base_fips_apt/apply.sh
@@ -13,6 +13,7 @@ FIPS_PKGS="openssh-client openssh-server openssl libssl1.1 libssl1.1-hmac libssl
 mock_grub_probe
 ua_attach
 ua_enable_fips
+write_fips_cmdline_conf
 install_and_hold_packages "${FIPS_PKGS}"
 ua_detach
 unmock_grub_probe


### PR DESCRIPTION
To have FIPS really enabled (/proc/sys/crypto/fips_enabled needs to
be 1), the kernel command line needs to have a fips=1
parameter. That's now set.