### PR TITLE
Fix grub cmdline fips=1 setting

### DIFF
--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -58,7 +58,9 @@ function install_and_hold_packages() {
 
 
 function write_fips_cmdline_conf() {
-    run_in_chroot ${chroot} "echo 'GRUB_CMDLINE_LINUX_DEFAULT=\"$GRUB_CMDLINE_LINUX_DEFAULT fips=1\"' > /etc/default/grub.d/99-fips.cfg"
+    cat << "EOF" >> "${chroot}/etc/default/grub.d/99-fips.cfg"
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT fips=1"
+EOF
 }
 
 


### PR DESCRIPTION
Commit fb762e7d0b61b8 added the change wronly and the build failed
with:

prelude_fips.bash: line 61: GRUB_CMDLINE_LINUX_DEFAULT: \
    unbound variable

This is now fixed.