### PR TITLE
Permissions fix  for `ubuntu-advantage` cache file

### DIFF
--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -112,6 +112,7 @@ function esm_enable {
   pkg_mgr install ubuntu-advantage-tools
   run_in_chroot $chroot "ua attach ${ESM_TOKEN} --no-auto-enable"
   run_in_chroot $chroot "ua enable esm-infra"
+  run_in_chroot $chroot "chmod a-x,o-w /tmp/ubuntu-advantage/candidate-version"
 }
 
 function esm_disable {


### PR DESCRIPTION
The change in this commit updates the `esm_enable` function so that it modifies the file permssions of
`/tmp/ubuntu-advantage/candidate-version` created by `ubuntu-advantage` from `777` -> `664` by stripping all execute permissions `a-x`, and removing write permissions for "other" `o-w`.

This is done so that the "stig: V-38643" test which validates that there are no "other" writeable files on the filesystem.

Once the file has been created the `ubuntu-advantage` tool does not appear to modify the permissions however the `esm_enable` function (re)sets the permissions on every invocation.

Context: the `ubuntu-advantage` / `ua` utility appears to be writing a file with `777` permissions, most likely because of [this commit](https://github.com/canonical/ubuntu-advantage-client/commit/ce808efa9fe4120e81d0424f4d9978da2f00cb78).