### PR TITLE
README replace download link for VMware ovftool 4.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ If you find yourself debugging any of the above processes, here is what you need
 ## External Assets
 
 The ovftool installer from VMWare can be found at
-[my.vmware.com](https://my.vmware.com/group/vmware/details?downloadGroup=OVFTOOL410&productId=489).
+[customerconnect.vmware.com](https://customerconnect.vmware.com/downloads/get-download?downloadGroup=OVFTOOL443).
 
 The ovftool installer must be copied into the [ci/docker/os-image-stemcell-builder-jammy](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/tree/master/ci/docker/os-image-stemcell-builder) next to the Dockerfile or you will receive the error
 


### PR DESCRIPTION
The original link was misleading to me. It pointed to an old version of ovftool.
Do you want me to create a PR for README in branch `ubuntu-bionic/master` as well?