### PR TITLE
update xenserver guest tools for jammy stemcell

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -296,6 +296,7 @@ SECTION 1: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
    >>> webmock-1.11.0
    >>> yajl-ruby-0.8.2
    >>> yajl-ruby-1.1.0
+   >>> xe-guest-utilities-7.30.0
 
 
 
@@ -3219,6 +3220,31 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+>>> xe-guest-utilities-7.30.0
+
+Copyright (C) Citrix Systems, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
 
 
 ADDITIONAL LICENSE INFORMATION:

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-cloudstack-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-cloudstack-additions.txt
@@ -1,3 +1,0 @@
-libxenstore3.0:amd64
-xe-guest-utilities
-xenstore-utils

--- a/stemcell_builder/stages/system_ubuntu_xen_tools/apply.sh
+++ b/stemcell_builder/stages/system_ubuntu_xen_tools/apply.sh
@@ -6,11 +6,30 @@ base_dir=$(readlink -nf "$(dirname "$0")/../..")
 source "$base_dir/lib/prelude_apply.bash"
 source "$base_dir/etc/settings.bash"
 
-debs="xe-guest-utilities xenstore-utils"
+# repository information
+# - for some reason, xe-guest-utilities@v7.31.0 build process creates
+#   a tarball with named with a different version
+ns="xenserver"
+repo="xe-guest-utilities"
+tag="v7.30.0"
+tarball="xe-guest-utilities_6.6.80-0_x86_64.tgz"
 
-pkg_mgr install $debs
+dir=$(mktemp -d)
 
-set -u
+# xen-tools sources
+# - the build process requires the directory name to be xe-guest-utilities
+mkdir "${dir}/${repo}"
+cd "${dir}/${repo}"
+curl -fsSL https://github.com/${ns}/${repo}/archive/refs/tags/${tag}.tar.gz | \
+  tar xvz --strip-components=1
+
+# xen-tools compilation
+go mod vendor
+mkdir vendor/${repo}
+make build
+
+# xen-tools installation
+tar xvzf ${dir}/${repo}/build/dist/${tarball} -C ${chroot}/
 
 # xen-tools configuration
 file=${chroot}/etc/sysctl.conf


### PR DESCRIPTION
This PR implements jammy compatibility for stemcells using xenserver hypervisor.

Since the package `xe-guest-utilities` is no longer available in apt for jammy steamline, Xenserver guest utilities should now be compiled from source. 

The PR also includes a copy the Citrix license as required when redistributing xen-guest-utilities binaries.