### PR TITLE
Installing ethtool in Jammy

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
@@ -63,6 +63,7 @@ dwz
 e2fsprogs
 eject
 emacsen-common
+ethtool
 fdisk
 file
 findutils

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -14,7 +14,8 @@ libaio1 gdb libcap2-bin libcap2-dev libbz2-dev \
 cmake uuid-dev libgcrypt-dev ca-certificates \
 scsitools mg htop module-assistant debhelper runit parted \
 cloud-guest-utils anacron software-properties-common \
-xfsprogs gdisk libpam-cracklib chrony dbus nvme-cli rng-tools fdisk"
+xfsprogs gdisk libpam-cracklib chrony dbus nvme-cli rng-tools fdisk \
+ethtool"
 
 if [[ "${DISTRIB_CODENAME}" == 'xenial' ]]; then
   debs="$debs libcurl3 libcurl3-dev module-init-tools"


### PR DESCRIPTION
Now the stemcell ships with ethtool, which is a tool that is occasionally useful to users facing networking problems.