### PR TITLE
🐞 Fix "Cannot connect to the monit daemon."

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
+++ b/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
@@ -9,4 +9,6 @@ then
 else
     iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
 	     -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
+    iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+	     -m state --state ESTABLISHED,RELATED -j ACCEPT
 fi


### PR DESCRIPTION
Intermittently, during BOSH tasks such as `bosh deploy`, we'd see failures such as the following:

```
L Error: Action Failed get_task: Task 4e2d3e05-be15-471b-5220-ec67584b08a9 result: Stopping Monitored Services: Stop all services: Running command: 'monit stop -g vcap', stdout: '', stderr: 'monit-actual: > Cannot connect to the monit daemon. Did you start it with http support?
monit-actual: Cannot connect to the monit daemon. Did you start it with http support?
': exit status 1
Task 2924 | 01:14:03 | Error: Action Failed get_task: Task 4e2d3e05-be15-471b-5220-ec67584b08a9 result: Stopping Monitored Services: Stop all services: Running command: 'monit stop -g vcap', stdout: '', stderr: 'monit-actual: > Cannot connect to the monit daemon. Did you start it with http support?
monit-actual: Cannot connect to the monit daemon. Did you start it with http support?
': exit status 1
```

The error was caused by a TCP RESET ("Connection Refused") being dropped by the current firewall rule "...` ! --cgroup xxx -j DROP`". Rather than closing the socket, this left the socket lingering in a `LAST-ACK` state for approximately 106-108 seconds. When `monit` is heavily active, that lingering socket could be randomly selected by a subsequent monit call, forcing a timeout.

The RESET was being dropped because it came from a kernel, which doesn't belong to the correct cgroup because the kernel doesn't belong to any cgroups because the kernel is not a process.

The reason the kernel is delivering the packet is that the sender with the correct cgroup is gone (has exited) and kernel is left with the responsibility of delivering the packet, and when the associated iptables rule is checked, there's no associated cgroup to the RESET packet, so the packet gets dropped, leaving a dangling connection.

This commit fixes that by inserting a rule which allows all packets that are already established.

Note that the command which allows "`ESTABLISHED`" connection appears _after_ the rule that "`DROP`"s connection; that's okay. Since we're inserting ("`-I`") the rules, they'll appear in the correct order.