### PR TITLE
bump cloudstack's mdproxy4cs

### DIFF
--- a/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/assets/install.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_ubuntu_vr_metadata/assets/install.sh
@@ -2,8 +2,8 @@
 set -e
 
 repo="orange-cloudfoundry/mdproxy4cs"
-version="1.0.0"
-name="mdproxy4cs-${version}.linux-amd64"
+version="1.10.0"
+name="mdproxy4cs_${version}_linux_amd64"
 file="${name}.tar.gz"
 dir=$(mktemp -d)
 
@@ -14,10 +14,10 @@ tar xz
 
 mkdir -p /usr/share/mdproxy4cs/
 
-cp "${name}/mdproxy4cs"         /usr/bin/
-cp "${name}/pre-start.sh"       /usr/share/mdproxy4cs/pre-start.sh
-cp "${name}/mdproxy4cs.service" /usr/share/mdproxy4cs/mdproxy4cs.service
-cp "${name}/default"            /etc/default/mdproxy4cs
+cp "${name}/mdproxy4cs"                /usr/bin/
+cp "${name}/assets/pre-start.sh"       /usr/share/mdproxy4cs/pre-start.sh
+cp "${name}/assets/mdproxy4cs.service" /usr/share/mdproxy4cs/mdproxy4cs.service
+cp "${name}/assets/default"            /etc/default/mdproxy4cs
 
 systemctl enable /usr/share/mdproxy4cs/mdproxy4cs.service
 


### PR DESCRIPTION
This PR bump the cloud init tool `mdproxy4cs` used on cloudstack's stemcell from `v1.0.0` to `v1.10.0`.

`v1.10.0` has no behaviour changes, it only keeps its internal dependencies up-to-date and brings minor changes on its packaging layout.