### PR TITLE
pkg name change

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
@@ -294,7 +294,7 @@ libpython3.10:amd64
 libquadmath0:amd64
 libreadline-dev:amd64
 libreadline8:amd64
-librelp0:amd64
+librelp0
 librhash0:amd64
 librtmp1:amd64
 libsasl2-2:amd64


### PR DESCRIPTION
notice error 
https://bosh.ci.cloudfoundry.org/teams/main/pipelines/stemcells-ubuntu-jammy/jobs/build-google-kvm-master/builds/256#L63c3bed4:5802

```
       the missing elements were:      ["librelp0:amd64"]
       the extra elements were:        ["librelp0"]
       ```