### PR TITLE
Ubuntu bionic ovftool

### DIFF
--- a/ci/docker/os-image-stemcell-builder-bionic/Dockerfile
+++ b/ci/docker/os-image-stemcell-builder-bionic/Dockerfile
@@ -60,8 +60,8 @@ ENV GOROOT=/usr/local/go PATH=/usr/local/go/bin:$PATH
 ADD scripts/update.sh /tmp/update.sh
 RUN /tmp/update.sh && rm /tmp/update.sh
 
-ENV OVF_TOOL_INSTALLER VMware-ovftool-4.4.3-18663434-lin.x86_64.bundle
-ENV OVF_TOOL_INSTALLER_SHA1 6c24e473be49c961cfc3bb16774b52b48e822991
+ENV OVF_TOOL_INSTALLER VMware-ovftool-4.1.0-2459827-lin.x86_64.bundle
+ENV OVF_TOOL_INSTALLER_SHA1 b907275c8d744bb54717d24bb8d414b19684fed4
 ADD ${OVF_TOOL_INSTALLER} /tmp/ovftool_installer.bundle
 ADD scripts/install-ovf.sh /tmp/install-ovf.sh
 RUN /tmp/install-ovf.sh && rm /tmp/install-ovf.sh


### PR DESCRIPTION
made a small copy paste mistake as bionic should still use ovftool 4.1.0