### PR TITLE
Fix walinuxagent crash on Azure

### DIFF
--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -5,7 +5,7 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-packages="python3 python3-pyasn1 python3-setuptools python-is-python3 cloud-init"
+packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 cloud-init"
 pkg_mgr install $packages
 
 wala_release=2.6.0.2


### PR DESCRIPTION
Distro package is missing on Azure. This leads to constant crashes of the walinuxagent

```
2023-03-08T16:30:30.653329Z INFO CollectLogsHandler ExtHandler Starting log collection...
Running scope as unit: collect-logs.scope
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/future.py", line 77, in get_linux_distribution
    supported = platform._supported_dists + (supported_dists,)
AttributeError: module 'platform' has no attribute '_supported_dists'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/sbin/waagent", line 35, in <module>
    import azurelinuxagent.agent as agent
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/agent.py", line 31, in <module>
    from azurelinuxagent.common import cgroupconfigurator, logcollector
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/cgroupconfigurator.py", line 23, in <module>
    from azurelinuxagent.common.cgroup import CpuCgroup, AGENT_NAME_TELEMETRY, MetricsCounter
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/cgroup.py", line 25, in <module>
    from azurelinuxagent.common.osutil import get_osutil
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/osutil/__init__.py", line 18, in <module>
    from azurelinuxagent.common.osutil.factory import get_osutil
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/osutil/factory.py", line 22, in <module>
    from azurelinuxagent.common.version import DISTRO_NAME, DISTRO_CODE_NAME, DISTRO_VERSION, DISTRO_FULL_NAME
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/version.py", line 227, in <module>
    __distro__ = get_distro()
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/version.py", line 113, in get_distro
    osinfo = get_linux_distribution(0, 'alpine')
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/future.py", line 95, in get_linux_distribution
    return get_linux_distribution_from_distro(get_full_name)
  File "/usr/local/lib/python3.10/dist-packages/azurelinuxagent/common/future.py", line 106, in get_linux_distribution_from_distro
    distro.linux_distribution(
NameError: name 'distro' is not defined
2023-03-08T16:30:32.356300Z INFO CollectLogsHandler ExtHandler Log Collector exited with code 1
```