### PR TITLE
fix the hypervisor_name for aws stemcell build

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The arguments to `stemcell:build_with_local_os_image` are:
 0. `infrastructure_name`: Which IaaS you are producing the stemcell for.
    Determines which virtualization tools to package on top of the stemcell.
 0. `hypervisor_name`: Depending on what the IAAS supports, which hypervisor to
-   target: `aws` → `xen`, `azure` → `hyperv`, `google` → `kvm`, `openstack` →
+   target: `aws` → `xen-hvm`, `azure` → `hyperv`, `google` → `kvm`, `openstack` →
    `kvm`, `vsphere` → `esxi`
 0. `operating_system_name` (`ubuntu`): Type of OS. Same as
    `stemcell:build_os_image`


### PR DESCRIPTION
Bosh director fails to deploy releases with a stemcell built with hypervisor_name `xen`

```
Task 16

Task 16 | 10:34:43 | Preparing deployment: Preparing deployment (00:00:00)
                   L Error: Stemcell version 'x.xx' for OS 'ubunty-jammy' doesn't exist
Task 16 | 10:34:43 | Error: Stemcell version 'x.xx' for OS 'ubunty-jammy' doesn't exist

Task 16 Started  Thu Mar 30 10:34:43 UTC 2023
Task 16 Finished Thu Mar 30 10:34:43 UTC 2023
Task 16 Duration 00:00:00
Task 16 error

Updating deployment:
  Expected task '16' to succeed but state is 'error'

Exit code 1
```

The documentation should be updated to suggest the correct hypervisor name (`xen-hvm`) for AWS