### PR TITLE
Add systemd config to prevent chronyd from locking bind mounts

### DIFF
--- a/bosh-stemcell/spec/support/os_image_systemd_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_systemd_shared_examples.rb
@@ -12,6 +12,11 @@ shared_examples_for 'a systemd-based OS image' do
       it { should be_enabled }
     end
 
+    describe file('/etc/systemd/system/chronyd.service.d/prevent_mount_locking.conf') do
+      it { should be_file }
+      its(:content) { should match /^InaccessiblePaths=-\/var\/vcap\/store/ }
+    end
+
     describe file('/etc/systemd/journald.conf.d/00-override.conf') do
       it { should be_file }
       its(:content) { should match /^Storage=volatile/ }

--- a/stemcell_builder/stages/bosh_ntp/apply.sh
+++ b/stemcell_builder/stages/bosh_ntp/apply.sh
@@ -10,3 +10,6 @@ sed -i "/^pool /d" $chroot/etc/chrony/chrony.conf
 cp $dir/assets/chrony-updater $chroot/$bosh_dir/bin/sync-time
 
 chmod 0755 $chroot/$bosh_dir/bin/sync-time
+
+mkdir -p "${chroot}/etc/systemd/system/chronyd.service.d"
+cp $dir/assets/prevent_mount_locking.conf "${chroot}/etc/systemd/system/chronyd.service.d"

--- a/stemcell_builder/stages/bosh_ntp/assets/prevent_mount_locking.conf
+++ b/stemcell_builder/stages/bosh_ntp/assets/prevent_mount_locking.conf
@@ -1,0 +1,2 @@
+[Service]
+InaccessiblePaths=-/var/vcap/store


### PR DESCRIPTION
Issue: https://github.com/cloudfoundry/bosh/issues/2433

Chrony's systemd config uses ReadWritePaths to limit the files it has access to. When this is configured, systemd creates a file system namespace for the service. This namespace ties up the existing bind mounts, even if the service isn't given access to those particular paths. This can cause disk unmounting to fail if the file namspace was created when that mounting existed.

This was most commonly seen when chrony had been restarted AFTER the persistent disk had been mounted. Normally when doing a persistent disk migration.

This changes adds back InaccessiblePaths to prevent the file namspace from having access to /var/vcap/store.

This work was done previously in: #152 but was lost as part of a later cleanup.