### PR TITLE
Azure chrony fix

### DIFF
--- a/stemcell_builder/stages/bosh_azure_chrony/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_chrony/apply.sh
@@ -6,7 +6,7 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
-cat > $chroot/etc/chrony/sources.d/azure_ptp.sources <<EOF
+cat > $chroot/etc/chrony/conf.d/azure_ptp.conf <<EOF
 # created by $0
 # https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
 refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0


### PR DESCRIPTION
Note that this PR is merely a file change—instead of being placed in the `sources.d/ ` subdirectory, the directive to use the reference clock is placed in the `conf.d/` subdirectory, for the directive to use the reference clock is **not** a source definition; rather, it's a configuration definition.

If placed in `source.d/`, the directive has no effect. [#184816605] Fix chrony azure phc config and update Ops Manager documentation