### PR TITLE
Fixing rsyslog for warden stemcells

### DIFF
--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -22,6 +22,9 @@ chmod +x /etc/sv/{ssh,rsyslog,cron}/run
 ln -s /etc/sv/{ssh,rsyslog,cron} /etc/service/
 "
 
+# Remove systemd setting from rsyslog as warden doesn't use systemd
+sed -i "/^\$SystemLogSocketName /d" /etc/rsyslog.conf
+
 # Pending for disk_quota
 #run_in_chroot $chroot "
 #ln -s /proc/self/mounts /etc/mtab


### PR DESCRIPTION
Warden stemcells uses runit and doesn't have systemd setup. Rsyslog doesn't work in warden stemcell with new jammy rsyslog conf, removing SystemLogSocketName fixes this issue.