### PR TITLE
Fix chroot command

### DIFF
--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -24,7 +24,7 @@ ln -s /etc/sv/{ssh,rsyslog,cron} /etc/service/
 
 # Remove systemd setting from rsyslog as warden doesn't use systemd
 run_in_chroot $chroot "
-sed -i '/^\$SystemLogSocketName /d' /etc/rsyslog.conf
+sed -i '/^\\\$SystemLogSocketName /d' /etc/rsyslog.conf
 "
 
 # Pending for disk_quota


### PR DESCRIPTION
- It'll definitely work this time.
- Necessary to escape the \ as well (which results in 3 \\\, the first two print a `\` and the latter one prints a `$`. This is because there are a few levels of bash interpolation occurring)