### PR TITLE
Add new stage to disable RemoveIPC in systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,13 @@ git clone git@github.com:cloudfoundry/bosh-linux-stemcell-builder.git
 cd bosh-linux-stemcell-builder
 git checkout ubuntu-jammy/master
 mkdir -p tmp
-ARCH=$(uname -m)
-[ $ARCH = "arm64" ] && DOCKER_OPTS=("--platform" "linux/x86_64") # macOS ARM + Rancher Desktop
-docker build \
-   --tag os-image-stemcell-builder-jammy \
-   $DOCKER_OPTS \
-   $PWD/ci/docker/os-image-stemcell-builder-jammy
 docker run \
    --privileged \
    -v "$(pwd):/opt/bosh" \
    --workdir /opt/bosh \
    --user=1000:1000 \
    -it \
-   $DOCKER_OPTS \
-   os-image-stemcell-builder-jammy
+   bosh/os-image-stemcell-builder:jammy
 # You're now in the the Docker container
 gem install bundler
 bundle

--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -281,6 +281,7 @@ module Bosh::Stemcell
         bosh_monit
         bosh_ntp
         bosh_sudoers
+        bosh_systemd
       ].flatten
     end
 

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -39,6 +39,7 @@ module Bosh::Stemcell
             :bosh_monit,
             :bosh_ntp,
             :bosh_sudoers,
+            :bosh_systemd,
             :password_policies,
             :restrict_su_command,
             :tty_config,

--- a/stemcell_builder/stages/bosh_systemd/apply.sh
+++ b/stemcell_builder/stages/bosh_systemd/apply.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/lib/prelude_bosh.bash
+
+# Disable RemoveIPC in systemd to prevent it from cleaning up shared files owned by vcap
+# Postgres for example gets the error message: could not open shared memory segment
+# because those files have been cleaned up
+run_in_chroot $chroot "
+echo 'RemoveIPC=no' >> /etc/systemd/logind.conf
+"


### PR DESCRIPTION
When RemoveIPC is enabled, it cleans up shared files for the vcap user which can cause problems for long running processes such as Postgres that depend on these shared files

Drive-by: We cleaned-up the README: we assume we're building on x86_64, And also we use the pre-built Docker image instead of building our own.