### PR TITLE
remove go_agent in the stemcell name

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ The arguments to `stemcell:build_with_local_os_image` are:
 You can find the resulting stemcell in the `tmp/` directory of the host, or in
 the `/opt/bosh/tmp` directory in the Docker container. Using the above example,
 the stemcell would be at
-`tmp/bosh-stemcell-0.0.8-vsphere-esxi-ubuntu-jammy-go_agent.tgz`. You can
+`tmp/bosh-stemcell-0.0.8-vsphere-esxi-ubuntu-jammy.tgz`. You can
 upload the stemcell to a vSphere BOSH Director:
 
 ```bash
-bosh upload-stemcell tmp/bosh-stemcell-0.0.8-vsphere-esxi-ubuntu-jammy-go_agent.tgz
+bosh upload-stemcell tmp/bosh-stemcell-0.0.8-vsphere-esxi-ubuntu-jammy.tgz
 ```
 
 ## Testing

--- a/bosh-stemcell/lib/bosh/stemcell/definition.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/definition.rb
@@ -27,7 +27,6 @@ module Bosh::Stemcell
       ]
       stemcell_name_parts << operating_system.version if operating_system.version
       stemcell_name_parts << operating_system.variant if operating_system.variant
-      stemcell_name_parts << 'go_agent'
       stemcell_name_parts << disk_format unless disk_format == infrastructure.default_disk_format
 
       stemcell_name_parts.join('-')

--- a/bosh-stemcell/spec/bosh/stemcell/definition_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/definition_spec.rb
@@ -82,7 +82,7 @@ module Bosh::Stemcell
     describe '#stemcell_name' do
       it 'builds a name from the infrastructure, hypervisor, os, and disk format' do
         expect(definition.stemcell_name('disk-format')).to eq(
-          'infrastructure-name-hypervisor-operating-system-name-operating_system_version-go_agent-disk-format'
+          'infrastructure-name-hypervisor-operating-system-name-operating_system_version-disk-format'
         )
       end
 
@@ -91,7 +91,7 @@ module Bosh::Stemcell
 
         it 'leaves off the os version' do
           expect(definition.stemcell_name('disk-format')).to eq(
-            'infrastructure-name-hypervisor-operating-system-name-go_agent-disk-format'
+            'infrastructure-name-hypervisor-operating-system-name-disk-format'
           )
         end
       end
@@ -101,7 +101,7 @@ module Bosh::Stemcell
 
         it 'leaves off the os version' do
           expect(definition.stemcell_name('disk-format')).to eq(
-            'infrastructure-name-hypervisor-operating-system-name-operating_system_version-variant-go_agent-disk-format'
+            'infrastructure-name-hypervisor-operating-system-name-operating_system_version-variant-disk-format'
           )
         end
       end
@@ -109,7 +109,7 @@ module Bosh::Stemcell
       context 'the disk format is the default' do
         it 'leaves it off' do
           expect(definition.stemcell_name('default-disk-format')).to eq(
-            'infrastructure-name-hypervisor-operating-system-name-operating_system_version-go_agent'
+            'infrastructure-name-hypervisor-operating-system-name-operating_system_version'
           )
         end
       end

--- a/bosh-stemcell/spec/bosh/stemcell/stemcell_packager_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stemcell_packager_spec.rb
@@ -97,7 +97,7 @@ describe Bosh::Stemcell::StemcellPackager do
       architecture = 'x86_64'
 
       expect(actual_manifest).to eq({
-        'name' => 'bosh-fake_infra-fake_hypervisor-ubuntu-xenial-go_agent-raw',
+        'name' => 'bosh-fake_infra-fake_hypervisor-ubuntu-xenial-raw',
         'version' => '1234',
         'bosh_protocol' => 1,
         'api_version' => 3,
@@ -105,7 +105,7 @@ describe Bosh::Stemcell::StemcellPackager do
         'operating_system' => 'ubuntu-xenial',
         'stemcell_formats' => ['stemcell-format-a', 'stemcell-format-b'],
         'cloud_properties' => {
-          'name' => 'bosh-fake_infra-fake_hypervisor-ubuntu-xenial-go_agent-raw',
+          'name' => 'bosh-fake_infra-fake_hypervisor-ubuntu-xenial-raw',
           'version' => '1234',
           'infrastructure' => 'fake_infra',
           'hypervisor' => 'fake_hypervisor',
@@ -122,7 +122,7 @@ describe Bosh::Stemcell::StemcellPackager do
 
     it 'returns the path of the created tarball' do
       expect(packager.package(disk_format)).to eq(
-        File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial-go_agent.tgz"))
+        File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial.tgz"))
     end
 
     context 'if an image already exist in the stemcell dir' do
@@ -139,7 +139,7 @@ describe Bosh::Stemcell::StemcellPackager do
     it 'archives the working dir' do
       packager.package(disk_format)
 
-      tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial-go_agent.tgz")
+      tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial.tgz")
       expect(File.exist?(tarball_path)).to eq(true)
 
       stemcell_contents_path = File.join(tmp_dir, 'stemcell-contents')
@@ -161,7 +161,7 @@ describe Bosh::Stemcell::StemcellPackager do
     it 'stemcell tarball contains files in proper order' do
       packager.package(disk_format)
 
-      tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial-go_agent.tgz")
+      tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial.tgz")
       expect(File.exist?(tarball_path)).to eq(true)
 
       stdout, _, _ = Open3.capture3("tar tf #{tarball_path}")
@@ -193,7 +193,7 @@ image
       it 'archives the working dir with a different tarball name' do
         packager.package(disk_format)
 
-        tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial-go_agent-raw.tgz")
+        tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-xenial-raw.tgz")
         expect(File.exist?(tarball_path)).to eq(true)
       end
     end
@@ -203,7 +203,7 @@ image
 
       it 'archives the working dir with a different tarball name' do
         packager.package(disk_format)
-        tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-bionic-fips-go_agent.tgz")
+        tarball_path = File.join(tarball_dir, "bosh-stemcell-1234-fake_infra-fake_hypervisor-ubuntu-bionic-fips.tgz")
         expect(File.exist?(tarball_path)).to eq(true)
       end
 


### PR DESCRIPTION
as the go agent is the only bosh agent installed. it makes no sense to add it in the file name.

with this change we will break some pipelines as they have filter that specifically states `go_agent`
example in the stemcell publisher pipeline.
https://github.com/cloudfoundry/bosh-stemcells-ci/blob/master/pipelines/publisher/pipeline.yml#L57