### PR TITLE
use snapshot apt when building from tag

### DIFF
--- a/bosh-stemcell/spec/os_image/ubuntu_jammy_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_jammy_spec.rb
@@ -36,9 +36,9 @@ describe 'Ubuntu 22.04 OS image', os_image: true do
 
   describe 'base_apt' do
     describe file('/etc/apt/sources.list') do
-      its(:content) { should match 'deb http://archive.ubuntu.com/ubuntu jammy main universe multiverse' }
-      its(:content) { should match 'deb http://archive.ubuntu.com/ubuntu jammy-updates main universe multiverse' }
-      its(:content) { should match 'deb http://security.ubuntu.com/ubuntu jammy-security main universe multiverse' }
+      its(:content) { should match 'deb http:\/\/(archive|snapshot).ubuntu.com\/ubuntu(|\/\d*T\d*Z) jammy main universe multiverse' }
+      its(:content) { should match 'deb http:\/\/(archive|snapshot).ubuntu.com\/ubuntu(|\/\d*T\d*Z) jammy-updates main universe multiverse' }
+      its(:content) { should match 'deb http:\/\/(security|snapshot).ubuntu.com\/ubuntu(|\/\d*T\d*Z) jammy-security main universe multiverse' }
     end
 
     describe file('/lib/systemd/system/runit.service') do

--- a/stemcell_builder/stages/base_apt/apply.sh
+++ b/stemcell_builder/stages/base_apt/apply.sh
@@ -8,11 +8,21 @@ source $base_dir/lib/prelude_apply.bash
 mount --bind /sys "$chroot/sys"
 add_on_exit "umount $chroot/sys"
 
-cat > "$chroot/etc/apt/sources.list" <<EOS
-deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe multiverse
-deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe multiverse
-deb http://security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe multiverse
+# check if current git branch is a tag and use snapshot date from the last commit message in that tag
+if git log -1 --format='%D' |grep "HEAD, tag:"; then
+  DATE=$(git log -1 --format="%at" | xargs -I{} date -d @{} +%Y%m%dT%H%M%SZ)
+  cat > "$chroot/etc/apt/sources.list" <<EOS
+  deb http://snapshot.ubuntu.com/ubuntu/$DATE $DISTRIB_CODENAME main universe multiverse
+  deb http://snapshot.ubuntu.com/ubuntu/$DATE $DISTRIB_CODENAME-updates main universe multiverse
+  deb http://snapshot.ubuntu.com/ubuntu/$DATE $DISTRIB_CODENAME-security main universe multiverse
 EOS
+else
+  cat > "$chroot/etc/apt/sources.list" <<EOS
+  deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe multiverse
+  deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe multiverse
+  deb http://security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe multiverse
+EOS
+fi
 
 # Upgrade systemd/upstart first, to prevent it from messing up our stubs and starting daemons anyway
 pkg_mgr install systemd


### PR DESCRIPTION
when building from a tag the tag date wil be used for setting the date for the snapshot apt.

this will give us the ability to replicate stemcell builds
except for the rsyslog packages at the moment