### PR TITLE
Enable esm-apps for use with ESM on Xenial

### DIFF
--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -110,12 +110,13 @@ function pkg_exists {
 function esm_enable {
   pkg_mgr install ca-certificates
   pkg_mgr install ubuntu-advantage-tools
-  run_in_chroot $chroot "ua attach ${ESM_TOKEN} --no-auto-enable"
-  run_in_chroot $chroot "ua enable esm-infra"
+  run_in_chroot $chroot "pro attach ${ESM_TOKEN} --no-auto-enable"
+  run_in_chroot $chroot "pro enable esm-infra"
+  run_in_chroot $chroot "pro enable esm-apps"
 }
 
 function esm_disable {
-  run_in_chroot $chroot "ua detach --assume-yes"
+  run_in_chroot $chroot "pro detach --assume-yes"
   pkg_mgr --purge --auto-remove remove ubuntu-advantage-tools
   run_in_chroot $chroot "rm -f /tmp/ubuntu-advantage/candidate-version"
 }


### PR DESCRIPTION
The ubuntu-advantage-tools CLI is also called `pro` now; while there's currently an alias for `ua`, that could change in the future, so we've pre-emptively started using the new name.

[#186639388] Update xenial stuff to use esm-apps in addition to esm-infra