### PR TITLE
Changes logrotate.timer trigger to OnCalendar

### DIFF
--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/smoke_test.go
@@ -29,7 +29,7 @@ func fillUpFileWithRandomCharacters(filepath string) {
 var _ = Describe("Stemcell", func() {
 	Context("when logrotate wtmp/btmp logs", func() {
 		It("should rotate the wtmp/btmp logs", func() {
-			stdOut, stdErr, exitStatus, err := bosh.Run("ssh", "default/0", `sudo sed -E -i "s/OnUnitActiveSec.*/OnUnitActiveSec=30s/" /etc/systemd/system/logrotate.timer && sudo sed -i "/RandomizedDelaySec/d" /etc/systemd/system/logrotate.timer && sudo systemctl daemon-reload`)
+			stdOut, stdErr, exitStatus, err := bosh.Run("ssh", "default/0", `sudo sed -E -i "s/OnCalendar.*/OnCalendar=*-*-* *:*:30/" /etc/systemd/system/logrotate.timer && sudo sed -i "/RandomizedDelaySec/d" /etc/systemd/system/logrotate.timer && sudo systemctl daemon-reload`)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exitStatus).To(Equal(0), fmt.Sprintf("stdOut: %s \n stdErr: %s", stdOut, stdErr))
 
@@ -43,7 +43,7 @@ var _ = Describe("Stemcell", func() {
 
 	Context("when syslog threshold limit is reached", func() {
 		It("should rotate the logs", func() {
-			_, _, exitStatus, err := bosh.Run("ssh", "default/0", `sudo sed -E -i "s/OnUnitActiveSec.*/OnUnitActiveSec=30s/" /etc/systemd/system/logrotate.timer && sudo sed -i "/RandomizedDelaySec/d" /etc/systemd/system/logrotate.timer && sudo systemctl daemon-reload`)
+			_, _, exitStatus, err := bosh.Run("ssh", "default/0", `sudo sed -E -i "s/OnCalendar.*/OnCalendar=*-*-* *:*:30/" /etc/systemd/system/logrotate.timer && sudo sed -i "/RandomizedDelaySec/d" /etc/systemd/system/logrotate.timer && sudo systemctl daemon-reload`)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exitStatus).To(Equal(0))
 

--- a/stemcell_builder/stages/logrotate_config/assets/logrotate.timer
+++ b/stemcell_builder/stages/logrotate_config/assets/logrotate.timer
@@ -4,7 +4,10 @@ Documentation=man:logrotate(8) man:logrotate.conf(5)
 
 [Timer]
 OnBootSec=1min
-OnUnitActiveSec=15min
+#This was once 'OnUnitActiveSec', but now is not. A Customer problem lead us to discover that it is said that
+#'oneshot' Units are never actually Active, so they will sometimes never be scheduled.
+#See: <https://github.com/systemd/systemd/issues/6680#issuecomment-326228938>
+OnCalendar=*-*-* *:00/15:00
 RandomizedDelaySec=2min
 Persistent=true
 


### PR DESCRIPTION
**NOTE**: This commit makes changes to the stemcell acceptance tests, but the commit author has not run those tests.

This commit changes the logrotate Timer Unit's scheduling mechanism from "OnUnitActiveSec" to "OnCalendar".

Why? A customer reported that on their Jammy-stemcell-based software, logrotate was never being run. Support reproduced the problem in their lab.

Investigation revealed that scheduling oneshot Timer Units with "OnUnitActiveSec" is something that has been long-known to be unsupported [1], and has had recent trouble reports from people running software on Jammy [2].

As further evidence of this change's likely correctness, Canonical also made a similar change for the same reason back in 2019. [3] (The programmer making the fix tries a few different things, but eventually discovers that "OnCalendar" works correctly. [4])

Unfortunately, this problem usually does not happen, and getting it TO happen can be very difficult, so proving the correctness of this fix is hard.

[1] <https://github.com/systemd/systemd/issues/6680#issuecomment-326228938>
[2] <https://github.com/systemd/systemd/issues/6680#issuecomment-1852339223>
[3] <https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/1829968>
[4] <https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/1829968/comments/5>