### PR TITLE
enable the use of iaas-specific kernels

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
@@ -52,6 +52,7 @@ module Bosh::Stemcell
         "cd #{STEMCELL_SPECS_DIR};",
         "STEMCELL_IMAGE=#{image_file_path}",
         "STEMCELL_WORKDIR=#{work_path}",
+        "STEMCELL_INFRASTRUCTURE=#{infrastructure.name}",
         "OS_NAME=#{operating_system.name}",
         "OS_VERSION=#{operating_system.version}",
         "CANDIDATE_BUILD_NUMBER=#{@version}",

--- a/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
@@ -63,7 +63,7 @@ module Bosh::Stemcell
         'UBUNTU_ISO' => environment['UBUNTU_ISO'],
         'UBUNTU_MIRROR' => environment['UBUNTU_MIRROR'],
         'UBUNTU_ADVANTAGE_TOKEN' => environment['UBUNTU_ADVANTAGE_TOKEN'],
-        'IAAS_KERNEL' => environment['IAAS_KERNEL'],
+        'UBUNTU_IAAS_KERNEL' => environment['UBUNTU_IAAS_KERNEL'],
       }
     end
 

--- a/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
@@ -63,6 +63,7 @@ module Bosh::Stemcell
         'UBUNTU_ISO' => environment['UBUNTU_ISO'],
         'UBUNTU_MIRROR' => environment['UBUNTU_MIRROR'],
         'UBUNTU_ADVANTAGE_TOKEN' => environment['UBUNTU_ADVANTAGE_TOKEN'],
+        'IAAS_KERNEL' => environment['IAAS_KERNEL'],
       }
     end
 

--- a/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
@@ -63,7 +63,7 @@ module Bosh::Stemcell
         'UBUNTU_ISO' => environment['UBUNTU_ISO'],
         'UBUNTU_MIRROR' => environment['UBUNTU_MIRROR'],
         'UBUNTU_ADVANTAGE_TOKEN' => environment['UBUNTU_ADVANTAGE_TOKEN'],
-        'UBUNTU_IAAS_KERNEL' => environment['UBUNTU_IAAS_KERNEL'],
+        'UBUNTU_FIPS_USE_IAAS_KERNEL' => environment['UBUNTU_FIPS_USE_IAAS_KERNEL'],
       }
     end
 

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-aws-fips.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-aws-fips.txt
@@ -1,0 +1,14 @@
+fips-initramfs
+kcapi-tools
+libgcrypt20-hmac:amd64
+libkcapi1:amd64
+linux-aws-fips
+linux-aws-fips-headers-5.15
+linux-headers-5.15-aws-fips
+linux-headers-aws-fips
+linux-image-5.15-aws-fips
+linux-image-aws-fips
+linux-image-hmac-5.15-aws-fips
+linux-modules-5.15-aws-fips
+microcode-initrd
+openssl-fips-module-3:amd64

--- a/bosh-stemcell/spec/stemcells/fips_spec.rb
+++ b/bosh-stemcell/spec/stemcells/fips_spec.rb
@@ -2,11 +2,9 @@ require 'spec_helper'
 
 describe 'FIPS Stemcell', os_image: true do
   context 'installed by system_kernel' do
-    iaas = ENV['UBUNTU_IAAS_KERNEL'] || ''
-    unless iaas.empty?
-      iaas = "#{iaas}-"
-    end
-    describe package("linux-image-#{iaas}fips") do
+    infrastructure = ENV['STEMCELL_INFRASTRUCTURE']
+    use_iaas_kernel = ENV['UBUNTU_FIPS_USE_IAAS_KERNEL']
+    describe package(use_iaas_kernel ? "linux-image-#{infrastructure}-fips" : "linux-image-fips") do
       it { should be_installed }
     end
     describe package('linux-generic') do
@@ -41,7 +39,7 @@ describe 'FIPS Stemcell', os_image: true do
     describe file('/boot/grub/grub.cfg') do
       it { should be_file }
       its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-fips root=UUID=\S* ro } }
-      if ENV.key?("UBUNTU_IAAS_KERNEL")
+      if ENV.key?("UBUNTU_FIPS_USE_IAAS_KERNEL")
         its(:content) { should match %r{initrd\t/boot/microcode.cpio /boot/initrd.img-\S+-fips} }
       else
         its(:content) { should match %r{initrd\t/boot/initrd.img-\S+-fips} }
@@ -74,8 +72,11 @@ describe 'FIPS Stemcell', os_image: true do
       exclude_on_openstack: true,
       exclude_on_softlayer: true,
     } do
+      let(:infrastructure) { ENV['STEMCELL_INFRASTRUCTURE'] }
+      let(:use_iaas_kernel) { ENV['UBUNTU_FIPS_USE_IAAS_KERNEL'] }
+
       it 'contains only the base set of packages plus aws-specific kernel packages' do
-        skip "Test skipped due to non-aws kernel" if (ENV['UBUNTU_IAAS_KERNEL'] != 'aws')
+        skip "Test skipped due to non-aws kernel" if (use_iaas_kernel && infrastructure != 'aws')
         pkg_list = dpkg_list_ubuntu.concat(dpkg_list_aws_fips_ubuntu)
         pkg_list.delete('linux-firmware')
         pkg_list.delete('wireless-regdb')
@@ -91,8 +92,10 @@ describe 'FIPS Stemcell', os_image: true do
       exclude_on_azure: true,
       exclude_on_softlayer: true,
     } do
+      let(:use_iaas_kernel) { ENV['UBUNTU_FIPS_USE_IAAS_KERNEL'] }
+
       it 'contains only the base set of packages for alicloud, aws, openstack, warden' do
-        skip "Test skipped due to IAAS-specific kernel" if ENV['UBUNTU_IAAS_KERNEL']
+        skip "Test skipped due to IAAS-specific kernel" if use_iaas_kernel
         expect(subject.stdout.split("\n")).to match_array(dpkg_list_ubuntu.concat(dpkg_list_fips_ubuntu))
       end
     end

--- a/bosh-stemcell/spec/stemcells/fips_spec.rb
+++ b/bosh-stemcell/spec/stemcells/fips_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'FIPS Stemcell', os_image: true do
   context 'installed by system_kernel' do
-    iaas = ENV['IAAS_KERNEL'] || ''
+    iaas = ENV['UBUNTU_IAAS_KERNEL'] || ''
     unless iaas.empty?
       iaas = "#{iaas}-"
     end
@@ -41,7 +41,7 @@ describe 'FIPS Stemcell', os_image: true do
     describe file('/boot/grub/grub.cfg') do
       it { should be_file }
       its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-fips root=UUID=\S* ro } }
-      if ENV.key?("IAAS_KERNEL")
+      if ENV.key?("UBUNTU_IAAS_KERNEL")
         its(:content) { should match %r{initrd\t/boot/microcode.cpio /boot/initrd.img-\S+-fips} }
       else
         its(:content) { should match %r{initrd\t/boot/initrd.img-\S+-fips} }
@@ -75,7 +75,7 @@ describe 'FIPS Stemcell', os_image: true do
       exclude_on_softlayer: true,
     } do
       it 'contains only the base set of packages plus aws-specific kernel packages' do
-        skip "Test skipped due to non-aws kernel" if (ENV['IAAS_KERNEL'] != 'aws')
+        skip "Test skipped due to non-aws kernel" if (ENV['UBUNTU_IAAS_KERNEL'] != 'aws')
         pkg_list = dpkg_list_ubuntu.concat(dpkg_list_aws_fips_ubuntu)
         pkg_list.delete('linux-firmware')
         pkg_list.delete('wireless-regdb')
@@ -92,7 +92,7 @@ describe 'FIPS Stemcell', os_image: true do
       exclude_on_softlayer: true,
     } do
       it 'contains only the base set of packages for alicloud, aws, openstack, warden' do
-        skip "Test skipped due to IAAS-specific kernel" if ENV['IAAS_KERNEL']
+        skip "Test skipped due to IAAS-specific kernel" if ENV['UBUNTU_IAAS_KERNEL']
         expect(subject.stdout.split("\n")).to match_array(dpkg_list_ubuntu.concat(dpkg_list_fips_ubuntu))
       end
     end

--- a/bosh-stemcell/spec/stemcells/fips_spec.rb
+++ b/bosh-stemcell/spec/stemcells/fips_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe 'FIPS Stemcell', os_image: true do
   context 'installed by system_kernel' do
-    describe package('linux-image-fips') do
+    iaas = ENV['IAAS_KERNEL'] || ''
+    unless iaas.empty?
+      iaas = "#{iaas}-"
+    end
+    describe package("linux-image-#{iaas}fips") do
       it { should be_installed }
     end
     describe package('linux-generic') do
@@ -37,7 +41,11 @@ describe 'FIPS Stemcell', os_image: true do
     describe file('/boot/grub/grub.cfg') do
       it { should be_file }
       its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-fips root=UUID=\S* ro } }
-      its(:content) { should match %r{initrd\t/boot/initrd.img-\S+-fips} }
+      if ENV.key?("IAAS_KERNEL")
+        its(:content) { should match %r{initrd\t/boot/microcode.cpio /boot/initrd.img-\S+-fips} }
+      else
+        its(:content) { should match %r{initrd\t/boot/initrd.img-\S+-fips} }
+      end
     end
   end
 
@@ -49,11 +57,31 @@ describe 'FIPS Stemcell', os_image: true do
 
     let(:dpkg_list_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy.txt')).map(&:chop) }
     let(:dpkg_list_fips_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy-fips.txt')).map(&:chop) }
+    let(:dpkg_list_aws_fips_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy-aws-fips.txt')).map(&:chop) }
     let(:dpkg_list_google_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy-google-additions.txt')).map(&:chop) }
     let(:dpkg_list_vsphere_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy-vsphere-additions.txt')).map(&:chop) }
     let(:dpkg_list_azure_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy-azure-additions.txt')).map(&:chop) }
     let(:dpkg_list_cloudstack_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy-cloudstack-additions.txt')).map(&:chop) }
     let(:dpkg_list_softlayer_ubuntu) { File.readlines(spec_asset('dpkg-list-ubuntu-jammy-softlayer-additions.txt')).map(&:chop) }
+
+    describe command(dpkg_list_packages), {
+      exclude_on_alicloud: true,
+      exclude_on_cloudstack: true,
+      exclude_on_vcloud: true,
+      exclude_on_vsphere: true,
+      exclude_on_warden: true,
+      exclude_on_azure: true,
+      exclude_on_openstack: true,
+      exclude_on_softlayer: true,
+    } do
+      it 'contains only the base set of packages plus aws-specific kernel packages' do
+        skip "Test skipped due to non-aws kernel" if (ENV['IAAS_KERNEL'] != 'aws')
+        pkg_list = dpkg_list_ubuntu.concat(dpkg_list_aws_fips_ubuntu)
+        pkg_list.delete('linux-firmware')
+        pkg_list.delete('wireless-regdb')
+        expect(subject.stdout.split("\n")).to match_array(pkg_list)
+      end
+    end
 
     describe command(dpkg_list_packages), {
       exclude_on_cloudstack: true,
@@ -64,6 +92,7 @@ describe 'FIPS Stemcell', os_image: true do
       exclude_on_softlayer: true,
     } do
       it 'contains only the base set of packages for alicloud, aws, openstack, warden' do
+        skip "Test skipped due to IAAS-specific kernel" if ENV['IAAS_KERNEL']
         expect(subject.stdout.split("\n")).to match_array(dpkg_list_ubuntu.concat(dpkg_list_fips_ubuntu))
       end
     end

--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -45,8 +45,8 @@ function update_kernel_static_libraries {
   major_kernel_version=${2}
 
   suffix=$kernel_suffix
-  if [ ! -z "$UBUNTU_IAAS_KERNEL" ]; then
-    suffix=-$UBUNTU_IAAS_KERNEL$kernel_suffix
+  if [ ! -z "$UBUNTU_FIPS_USE_IAAS_KERNEL" ]; then
+    suffix=-$stemcell_infrastructure$kernel_suffix
   fi
   kernel_version=$(find $chroot/usr/src/ -name "linux-headers-$major_kernel_version.*$kernel_suffix" | grep -o "[0-9].*-[0-9]*$suffix")
   sed -i "s/__KERNEL_VERSION__/$kernel_version/g" $chroot/var/vcap/bosh/etc/static_libraries_list

--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -45,8 +45,8 @@ function update_kernel_static_libraries {
   major_kernel_version=${2}
 
   suffix=$kernel_suffix
-  if [ ! -z "$IAAS_KERNEL" ]; then
-    suffix=-$IAAS_KERNEL$kernel_suffix
+  if [ ! -z "$UBUNTU_IAAS_KERNEL" ]; then
+    suffix=-$UBUNTU_IAAS_KERNEL$kernel_suffix
   fi
   kernel_version=$(find $chroot/usr/src/ -name "linux-headers-$major_kernel_version.*$kernel_suffix" | grep -o "[0-9].*-[0-9]*$suffix")
   sed -i "s/__KERNEL_VERSION__/$kernel_version/g" $chroot/var/vcap/bosh/etc/static_libraries_list

--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -44,7 +44,11 @@ function update_kernel_static_libraries {
   kernel_suffix=${1}
   major_kernel_version=${2}
 
-  kernel_version=$(find $chroot/usr/src/ -name "linux-headers-$major_kernel_version.*$kernel_suffix" | grep -o "[0-9].*-[0-9]*$kernel_suffix")
+  suffix=$kernel_suffix
+  if [ ! -z "$IAAS_KERNEL" ]; then
+    suffix=-$IAAS_KERNEL$kernel_suffix
+  fi
+  kernel_version=$(find $chroot/usr/src/ -name "linux-headers-$major_kernel_version.*$kernel_suffix" | grep -o "[0-9].*-[0-9]*$suffix")
   sed -i "s/__KERNEL_VERSION__/$kernel_version/g" $chroot/var/vcap/bosh/etc/static_libraries_list
 
   # since kernel 6.5 the objtool/libsubcmd.a has been moved to objtool/libsubcmd/libsubcmd.a

--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -12,10 +12,10 @@ if [ -z ${UBUNTU_ADVANTAGE_TOKEN} ]; then
     exit 1
 fi
 
-# verify that UBUNTU_IAAS_KERNEL is valid if set
-if [ ! -z ${UBUNTU_IAAS_KERNEL} ] && [ "$UBUNTU_IAAS_KERNEL" != "aws" ]; then
+# verify that IAAS kernel is a valid option (i.e. aws for now)
+if [ ! -z ${UBUNTU_FIPS_USE_IAAS_KERNEL} ] && [ "$stemcell_infrastructure" != "aws" ]; then
     echo "'aws' is the only currently-supported IAAS kernel."
-    echo "please unset UBUNTU_IAAS_KERNEL or set it to 'aws'"
+    echo "please unset UBUNTU_FIPS_USE_IAAS_KERNEL for non-aws builds"
     exit 1
 fi
 

--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -12,6 +12,13 @@ if [ -z ${UBUNTU_ADVANTAGE_TOKEN} ]; then
     exit 1
 fi
 
+# verify that UBUNTU_IAAS_KERNEL is valid if set
+if [ ! -z ${UBUNTU_IAAS_KERNEL} ] && [ "$UBUNTU_IAAS_KERNEL" != "aws" ]; then
+    echo "'aws' is the only currently-supported IAAS kernel."
+    echo "please unset UBUNTU_IAAS_KERNEL or set it to 'aws'"
+    exit 1
+fi
+
 function write_ua_client_config() {
     local iaas=${1}
 

--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -19,16 +19,6 @@ if [ ! -z ${UBUNTU_IAAS_KERNEL} ] && [ "$UBUNTU_IAAS_KERNEL" != "aws" ]; then
     exit 1
 fi
 
-function write_ua_client_config() {
-    local iaas=${1}
-
-    # overwrite the cloud type so the correct kernel gets installed
-    if [ -z "${iaas}" ]; then
-        echo "settings_overrides:" >> ${chroot}/etc/ubuntu-advantage/uaclient.conf
-        echo "  cloud_type: ${iaas}" >> ${chroot}/etc/ubuntu-advantage/uaclient.conf
-    fi
-}
-
 function ua_attach() {
     echo "Setting up Ubuntu Advantage ..."
 

--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -12,6 +12,16 @@ if [ -z ${UBUNTU_ADVANTAGE_TOKEN} ]; then
     exit 1
 fi
 
+function write_ua_client_config() {
+    local iaas=${1}
+
+    # overwrite the cloud type so the correct kernel gets installed
+    if [ -z "${iaas}" ]; then
+        echo "settings_overrides:" >> ${chroot}/etc/ubuntu-advantage/uaclient.conf
+        echo "  cloud_type: ${iaas}" >> ${chroot}/etc/ubuntu-advantage/uaclient.conf
+    fi
+}
+
 function ua_attach() {
     echo "Setting up Ubuntu Advantage ..."
 

--- a/stemcell_builder/stages/base_fips_apt/apply.sh
+++ b/stemcell_builder/stages/base_fips_apt/apply.sh
@@ -15,9 +15,6 @@ FIPS_PKGS="openssh-client openssh-server openssl openssl-fips-module-3 libssl3 l
 
 mock_grub_probe
 ua_attach
-if [ ! -z "$UBUNTU_IAAS_KERNEL" ]; then
-    write_ua_client_config "$UBUNTU_IAAS_KERNEL"
-fi
 ua_enable_fips
 write_fips_cmdline_conf
 pkg_mgr install --allow-downgrades "${FIPS_PKGS}"

--- a/stemcell_builder/stages/base_fips_apt/apply.sh
+++ b/stemcell_builder/stages/base_fips_apt/apply.sh
@@ -15,6 +15,9 @@ FIPS_PKGS="openssh-client openssh-server openssl openssl-fips-module-3 libssl3 l
 
 mock_grub_probe
 ua_attach
+if [ ! -z "$IAAS_KERNEL" ]; then
+    write_ua_client_config "$IAAS_KERNEL"
+fi
 ua_enable_fips
 write_fips_cmdline_conf
 pkg_mgr install --allow-downgrades "${FIPS_PKGS}"

--- a/stemcell_builder/stages/base_fips_apt/apply.sh
+++ b/stemcell_builder/stages/base_fips_apt/apply.sh
@@ -15,8 +15,8 @@ FIPS_PKGS="openssh-client openssh-server openssl openssl-fips-module-3 libssl3 l
 
 mock_grub_probe
 ua_attach
-if [ ! -z "$IAAS_KERNEL" ]; then
-    write_ua_client_config "$IAAS_KERNEL"
+if [ ! -z "$UBUNTU_IAAS_KERNEL" ]; then
+    write_ua_client_config "$UBUNTU_IAAS_KERNEL"
 fi
 ua_enable_fips
 write_fips_cmdline_conf

--- a/stemcell_builder/stages/system_fips_kernel/apply.sh
+++ b/stemcell_builder/stages/system_fips_kernel/apply.sh
@@ -15,8 +15,8 @@ mock_grub_probe
 ua_attach
 ua_enable_fips
 kernel=linux-fips
-if [ ! -z "$IAAS_KERNEL" ]; then
-    kernel=linux-$IAAS_KERNEL-fips
+if [ ! -z "$UBUNTU_IAAS_KERNEL" ]; then
+    kernel=linux-$UBUNTU_IAAS_KERNEL-fips
 fi
 pkg_mgr install fips-initramfs $kernel
 ua_detach

--- a/stemcell_builder/stages/system_fips_kernel/apply.sh
+++ b/stemcell_builder/stages/system_fips_kernel/apply.sh
@@ -15,8 +15,8 @@ mock_grub_probe
 ua_attach
 ua_enable_fips
 kernel=linux-fips
-if [ ! -z "$UBUNTU_IAAS_KERNEL" ]; then
-    kernel=linux-$UBUNTU_IAAS_KERNEL-fips
+if [ ! -z "$UBUNTU_FIPS_USE_IAAS_KERNEL" ]; then
+    kernel=linux-$stemcell_infrastructure-fips
 fi
 pkg_mgr install fips-initramfs $kernel
 ua_detach

--- a/stemcell_builder/stages/system_fips_kernel/apply.sh
+++ b/stemcell_builder/stages/system_fips_kernel/apply.sh
@@ -14,6 +14,10 @@ add_on_exit "umount $chroot/sys"
 mock_grub_probe
 ua_attach
 ua_enable_fips
-pkg_mgr install fips-initramfs linux-fips
+kernel=linux-fips
+if [ ! -z "$IAAS_KERNEL" ]; then
+    kernel=linux-$IAAS_KERNEL-fips
+fi
+pkg_mgr install fips-initramfs $kernel
 ua_detach
 unmock_grub_probe


### PR DESCRIPTION
Use `UBUNTU_IAAS_KERNEL` environment variable to identify the use of, and label for, iaas specific kernels (e.g. `aws`)

This somewhat replicates how fips was handled in the bionic branch, but with an attempt to be more generic.