### PR TITLE
Add usg to jammy-fips builds

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-fips.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-fips.txt
@@ -1,7 +1,9 @@
+bsdmainutils
 fips-initramfs
 kcapi-tools
 libgcrypt20-hmac:amd64
 libkcapi1:amd64
+libopenscap8
 linux-fips
 linux-fips-headers-5.15
 linux-headers-5.15-fips
@@ -11,4 +13,7 @@ linux-image-fips
 linux-image-hmac-5.15-fips
 linux-modules-5.15-fips
 linux-modules-extra-5.15-fips
+ncal
 openssl-fips-module-3:amd64
+usg
+usg-benchmarks-1

--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -40,6 +40,10 @@ function ua_enable_fips() {
     run_in_chroot_without_apt ${chroot} "ua enable --assume-yes fips-preview"
 }
 
+function ua_enable_usg() {
+    run_in_chroot_without_apt ${chroot} "ua enable --assume-yes usg"
+}
+
 function run_in_chroot_without_apt() {
     local chroot=${1}
     local script=${2}

--- a/stemcell_builder/stages/base_fips_apt/apply.sh
+++ b/stemcell_builder/stages/base_fips_apt/apply.sh
@@ -12,12 +12,14 @@ mount --bind /sys "$chroot/sys"
 add_on_exit "umount $chroot/sys"
 
 FIPS_PKGS="openssh-client openssh-server openssl openssl-fips-module-3 libssl3 libssl-dev libgcrypt20 libgcrypt20-hmac libgcrypt20-dev"
+USG_PKGS="usg bsdmainutils libopenscap8 ncal usg usg-benchmarks-1"
 
 mock_grub_probe
 ua_attach
 ua_enable_fips
+ua_enable_usg
 write_fips_cmdline_conf
-pkg_mgr install --allow-downgrades "${FIPS_PKGS}"
+pkg_mgr install --allow-downgrades "${FIPS_PKGS}" "${USG_PKGS}"
 ua_detach
 unmock_grub_probe
 


### PR DESCRIPTION
while not strictly required for fips, there is high overlap between users of fips images and various hardening profiles provided by usg