### PR TITLE
DRAFT: Comply with suggestions from the ssh-audit tool.

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -215,10 +215,10 @@ shared_examples_for 'every OS image' do
       expect(sshd_config.content).to_not match(/HostKey \/etc\/ssh\/ssh_host_dsa_key$/)
     end
 
-    it 'enables RSA, ECDSA, ED25519 host keys', exclude_on_fips: true do
-      matches = sshd_config.content.scan(/^HostKey.*/)
+    it 'enables RSA, ED25519 host keys', exclude_on_fips: true do
+      matches = sshd_config.content.scan(/^HostKey \/.*/)
 
-      expect(matches).to contain_exactly('HostKey /etc/ssh/ssh_host_rsa_key', 'HostKey /etc/ssh/ssh_host_ecdsa_key', 'HostKey /etc/ssh/ssh_host_ed25519_key')
+      expect(matches).to contain_exactly('HostKey /etc/ssh/ssh_host_rsa_key', 'HostKey /etc/ssh/ssh_host_ed25519_key')
     end
 
     it 'disallows X11 forwarding' do

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -67,13 +67,24 @@ sed "/^ *DenyUsers/d" -i $chroot/etc/ssh/sshd_config
 echo 'DenyUsers root' >> $chroot/etc/ssh/sshd_config
 
 sed "/^[ #]*HostKey \/etc\/ssh\/ssh_host_dsa_key/d" -i $chroot/etc/ssh/sshd_config
-for type in {rsa,ecdsa,ed25519}; do
+for type in {rsa,ed25519}; do
   sed "s/^[ #]*HostKey \/etc\/ssh\/ssh_host_${type}_key/HostKey \/etc\/ssh\/ssh_host_${type}_key/" -i $chroot/etc/ssh/sshd_config
 done
 
 #  Allow only 3DES and AES series ciphers
 sed "/^ *Ciphers/d" -i $chroot/etc/ssh/sshd_config
 echo 'Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr' >> $chroot/etc/ssh/sshd_config
+
+# Allow only rsa-sha2-512,rsa-sha2-256,ssh-ed25519 Host Key Algorithms
+sed "/^ *HostKeyAlgorithms/d" -i $chroot/etc/ssh/sshd_config
+echo 'HostKeyAlgorithms ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+' >> $chroot/etc/ssh/sshd_config
+
+# Allow only safe kex algorithms
+sed "/^ *KexAlgorithms/d" -i $chroot/etc/ssh/sshd_config
+echo 'sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256,kex-strict-s-v00@openssh.com
+' >> $chroot/etc/ssh/sshd_config
+echo 'curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,kex-strict-s-v00@openssh.com'
 
 # Disallow Weak MACs
 sed "/^ *MACs/d" -i $chroot/etc/ssh/sshd_config


### PR DESCRIPTION
The `ssh-audit` tool suggest to remove certain algorithms from the ssh configuration:

```
(kex) ecdh-sha2-nistp256                    -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
(kex) ecdh-sha2-nistp384                    -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
(kex) ecdh-sha2-nistp521                    -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
(key) ecdsa-sha2-nistp256                   -- [fail] using elliptic curves that are suspected as being backdoored by the U.S. National Security Agency
(kex) diffie-hellman-group14-sha256         -- [warn] 2048-bit modulus only provides 112-bits of symmetric strength
```

This commit removes them in our standard jammy stemcell ssh configuration.

However, ecdh and ecdsa algorithms are FIPS compliant. So it's open for discussion if this is a better security posture, and if it is, then it is safe to merge this commit.