### PR TITLE
Update walinuxagent to 2.9.1.1

### DIFF
--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -8,8 +8,8 @@ source $base_dir/lib/prelude_apply.bash
 packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 cloud-init"
 pkg_mgr install $packages
 
-wala_release=2.6.0.2
-wala_expected_sha1=8acc20f81082fee6a7aab2880077ae31f27d93ea
+wala_release=2.9.1.1
+wala_expected_sha1=b61bd57f3b2f7b048d6bab2739690bbf1d9c213b
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')


### PR DESCRIPTION
We noticed the currently included walinuxagent hasn't been updated for quite some time, so perhaps a more recent one can be used.