### PR TITLE
Revert from hwe kernel to normal lts kernel

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txt
@@ -1,4 +1,4 @@
-bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txtlinux-generic
+linux-generic
 linux-headers-5.15
 linux-headers-5.15-generic
 linux-headers-generic

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txt
@@ -1,5 +1,5 @@
-linux-generic
-linux-5.15-headers-5.15
+bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txtlinux-generic
+linux-headers-5.15
 linux-headers-5.15-generic
 linux-headers-generic
 linux-image-5.15-generic

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-kernel.txt
@@ -1,8 +1,8 @@
-linux-generic-hwe-22.04
-linux-hwe-6.5-headers-6.5
-linux-headers-6.5-generic
-linux-headers-generic-hwe-22.04
-linux-image-6.5-generic
-linux-image-generic-hwe-22.04
-linux-modules-6.5-generic
-linux-modules-extra-6.5-generic
+linux-generic
+linux-5.15-headers-5.15
+linux-headers-5.15-generic
+linux-headers-generic
+linux-image-5.15-generic
+linux-image-generic
+linux-modules-5.15-generic
+linux-modules-extra-5.15-generic

--- a/bosh-stemcell/spec/stemcells/fips_spec.rb
+++ b/bosh-stemcell/spec/stemcells/fips_spec.rb
@@ -5,7 +5,7 @@ describe 'FIPS Stemcell', os_image: true do
     describe package('linux-image-fips') do
       it { should be_installed }
     end
-    describe package('linux-generic-hwe-22.04') do
+    describe package('linux-generic') do
       it { should_not be_installed }
     end
     describe package('linux-image-5.19.0-109-generic') do

--- a/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
@@ -436,7 +436,7 @@ HERE
   end
 
   context 'installed by system_kernel', exclude_on_fips: true  do
-    describe package('linux-generic-hwe-22.04') do
+    describe package('linux-generic') do
       it { should be_installed }
     end
   end

--- a/stemcell_builder/stages/static_libraries_config/apply.sh
+++ b/stemcell_builder/stages/static_libraries_config/apply.sh
@@ -13,7 +13,7 @@ kernel_suffix="-generic"
 if [[ "${DISTRIB_CODENAME}" == 'bionic' ]]; then
     major_kernel_version="5.4"
 elif [[ "${DISTRIB_CODENAME}" == 'jammy' ]]; then
-    major_kernel_version="6.5"
+    major_kernel_version="5.15"
 else
     major_kernel_version="4.15"
 fi

--- a/stemcell_builder/stages/static_libraries_config/assets/jammy_static_libraries_list.txt
+++ b/stemcell_builder/stages/static_libraries_config/assets/jammy_static_libraries_list.txt
@@ -155,4 +155,5 @@
 /usr/lib/x86_64-linux-gnu/libz.a
 /usr/src/linux-headers-__KERNEL_VERSION__/tools/bpf/resolve_btfids/libbpf/libbpf.a
 /usr/src/linux-headers-__KERNEL_VERSION__/tools/bpf/resolve_btfids/libsubcmd/libsubcmd.a
+/usr/src/linux-headers-__KERNEL_VERSION__/tools/objtool/libsubcmd.a
 /usr/src/linux-headers-__KERNEL_VERSION__/tools/objtool/libsubcmd/libsubcmd.a

--- a/stemcell_builder/stages/system_kernel/apply.sh
+++ b/stemcell_builder/stages/system_kernel/apply.sh
@@ -14,7 +14,7 @@ mkdir -p $chroot/tmp
 if [[  "${DISTRIB_CODENAME}" == "bionic" ]]; then
   pkg_mgr install linux-generic-hwe-18.04
 elif [[  "${DISTRIB_CODENAME}" == "jammy" ]]; then
-  pkg_mgr install initramfs-tools linux-generic-hwe-22.04
+  pkg_mgr install initramfs-tools linux-generic
 elif [[ "${DISTRIB_CODENAME}" == "xenial" ]]; then
   pkg_mgr install linux-generic-hwe-16.04
 else


### PR DESCRIPTION
We've seen OOM problems when running cgroups v1 with the 6.5 kernel line.

Resolves #318

The plan is to test this before releasing it. So we'd like to merge it and then use the test stemcells to verify hardware compatibility with the kernel.

Once the stemcells are built in the pipeline, we'll reference the URLs in #318 so people have a chance to take a look at them.

Earliest date we'd want to release this is Monday March 11th.