### PR TITLE
Install and expect ubuntu-pro-client rather than ubuntu-advantage-tools

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
@@ -458,6 +458,7 @@ tcpdump
 traceroute
 tzdata
 ubuntu-advantage-tools
+ubuntu-pro-client
 ubuntu-keyring
 ucf
 udev

--- a/stemcell_builder/lib/prelude_fips.bash
+++ b/stemcell_builder/lib/prelude_fips.bash
@@ -15,7 +15,7 @@ fi
 function ua_attach() {
     echo "Setting up Ubuntu Advantage ..."
 
-    DEBIAN_FRONTEND=noninteractive run_in_chroot ${chroot} "apt-get install --assume-yes ubuntu-advantage-tools"
+    DEBIAN_FRONTEND=noninteractive run_in_chroot ${chroot} "apt-get install --assume-yes ubuntu-pro-client"
 
     run_in_chroot ${chroot} "ua attach --no-auto-enable ${UBUNTU_ADVANTAGE_TOKEN}"
 }


### PR DESCRIPTION
ubuntu-advantage-tools is being replaced with ubuntu-pro-client. ubuntu-advantage-tools is now a transitional package that just installs ubuntu-pro-client, but will still be installed while in a transitional state.

This likely affects (or will soon affect) bionic, but I haven't tested there