### PR TITLE
Documents why we're now using the non-HWE kernel

### DIFF
--- a/stemcell_builder/stages/system_kernel/apply.sh
+++ b/stemcell_builder/stages/system_kernel/apply.sh
@@ -14,6 +14,14 @@ mkdir -p $chroot/tmp
 if [[  "${DISTRIB_CODENAME}" == "bionic" ]]; then
   pkg_mgr install linux-generic-hwe-18.04
 elif [[  "${DISTRIB_CODENAME}" == "jammy" ]]; then
+  ## As was discussed in Bosh Ecosystem Team Retro on 2024-02-14, team policy is now
+  ## to publish stemcells that use non-HWE kernels so that we ship stemcells that
+  ## use LTS kernels. We've decided to switch to LTS kernels in the hopes that we will
+  ## see a lower defect rate than with the HWE kernels, which seem to roughly track
+  ## the latest kernel version. For Jammy and subsequent stemcell lines (that is Noble
+  ## and later), don't switch to the HWE kernels unless you have a good reason and
+  ## have discussed it with the rest of the team, or whoever is currently responsible
+  ## for the Linux Stemcell.
   pkg_mgr install initramfs-tools linux-generic
 elif [[ "${DISTRIB_CODENAME}" == "xenial" ]]; then
   pkg_mgr install linux-generic-hwe-16.04


### PR DESCRIPTION
This commit adds some small justification for switching away from the HWE kernel and going back to the -generic kernels, as well as some notes about who to contact if one is considering switching back to the HWE kernel.

This is being added so that someone 6, 12, 24 months from now will have at least SOME reason why we decided to use the LTS kernels over the HWE kernels, and have an idea of who to talk to if they want to revert this decision.