### PR TITLE
Fix overlooked unit test after merge

### DIFF
--- a/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
@@ -206,6 +206,7 @@ module Bosh::Stemcell
           "cd #{stemcell_specs_dir};",
           "STEMCELL_IMAGE=#{File.join(work_path, 'fake-root-disk-image.raw')}",
           "STEMCELL_WORKDIR=#{work_path}",
+          "STEMCELL_INFRASTRUCTURE=#{infrastructure.name}",
           "OS_NAME=#{operating_system.name}",
           "OS_VERSION=#{operating_system.version}",
           "CANDIDATE_BUILD_NUMBER=#{version}",


### PR DESCRIPTION
PR #309 broken an existing unit test, which first failed mysteriously with an obscure error:

```
TypeError:
  superclass mismatch for class File
```

This masked the real error, which was that the expected value didn't include the output from the new variable, `STEMCELL_INFRASTRUCTURE` which was added in https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/309