### PR TITLE
Add EFI support for vsphere stemcell

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/disk_image.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/disk_image.rb
@@ -14,17 +14,16 @@ module Bosh::Stemcell
     end
 
     def mount
-      device_path   = stemcell_loopback_device_name
-      mount_command = "sudo mount #{device_path} #{image_mount_point}"
-      shell.run(mount_command, output_command: verbose)
+      mount_image
     rescue => e
-      raise e unless e.message.include?(mount_command)
+      raise e unless e.message.include?("sudo mount")
 
       sleep 0.5
-      shell.run(mount_command, output_command: verbose)
+      mount_image
     end
 
     def unmount
+      shell.run("sudo umount #{image_mount_point}/boot/efi", output_command: verbose) if efi_image
       shell.run("sudo umount #{image_mount_point}", output_command: verbose)
     ensure
       unmap_image
@@ -34,6 +33,19 @@ module Bosh::Stemcell
 
     attr_reader :image_file_path, :verbose, :shell, :device
 
+    def mount_image
+      if efi_image
+        shell.run("sudo mount #{stemcell_loopback_boot_name} #{image_mount_point}", output_command: verbose)
+        shell.run("sudo mount -o umask=0177 #{stemcell_loopback_efi_name} #{image_mount_point}/boot/efi", output_command: verbose)
+      else
+        shell.run("sudo mount #{stemcell_loopback_device_name} #{image_mount_point}", output_command: verbose)
+      end
+    end
+
+    def efi_image
+      return map_image.lines.length > 1
+    end
+
     def stemcell_loopback_device_name
       split_output = map_image.split(' ')
       device_name  = split_output[2]
@@ -41,9 +53,21 @@ module Bosh::Stemcell
       File.join('/dev/mapper', device_name)
     end
 
+    def stemcell_loopback_boot_name
+      efi_partition = map_image.lines.last.split(' ')[2]
+      File.join('/dev/mapper', efi_partition)
+    end
+
+    def stemcell_loopback_efi_name
+      efi_partition = map_image.lines.first.split(' ')[2]
+      File.join('/dev/mapper', efi_partition)
+    end
+
     def map_image
+      return @map_image if @map_image
       @device = shell.run("sudo losetup --show --find #{image_file_path}", output_command: verbose)
-      shell.run("sudo kpartx -sav #{device}", output_command: verbose)
+      @map_image = shell.run("sudo kpartx -sav #{device}", output_command: verbose)
+      @map_image
     end
 
     def unmap_image

--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -144,8 +144,8 @@ module Bosh::Stemcell
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
-        :image_create,
-        :image_install_grub,
+        :image_create_efi,
+        :image_install_grub_efi,
         :sbom_create,
       ]
     end

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy.txt
@@ -90,6 +90,7 @@ grub-common
 grub-gfxpayload-lists
 grub-pc
 grub-pc-bin
+grub-efi-amd64-bin
 grub2
 grub2-common
 gzip

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -253,8 +253,8 @@ module Bosh::Stemcell
               :bosh_enable_password_authentication,
               :bosh_vsphere_agent_settings,
               :bosh_clean_ssh,
-              :image_create,
-              :image_install_grub,
+              :image_create_efi,
+              :image_install_grub_efi,
               :sbom_create,
               :bosh_package_list,
             ]
@@ -281,8 +281,8 @@ module Bosh::Stemcell
                 :bosh_enable_password_authentication,
                 :bosh_vsphere_agent_settings,
                 :bosh_clean_ssh,
-                :image_create,
-                :image_install_grub,
+                :image_create_efi,
+                :image_install_grub_efi,
                 :sbom_create,
                 :bosh_package_list,
             ]

--- a/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
@@ -9,7 +9,8 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
   linux_version_regex = 's/linux-(.+)-([0-9]+).([0-9]+).([0-9]+)-([0-9]+)/linux-\1-\2.\3/'
 
   context 'installed by image_install_grub', {
-    exclude_on_softlayer: true
+    exclude_on_softlayer: true,
+    exclude_on_vsphere: true,
   } do
     context 'for cloudstack infrastructure and xen hypervisor', {
         exclude_on_alicloud: true,
@@ -43,6 +44,44 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
 
     context 'for default kernel', exclude_on_fips: true do
       describe file('/boot/grub/grub.cfg') do
+        it { should be_file }
+        its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-generic root=UUID=\S* ro } }
+        its(:content) { should match %r{initrd\t/boot/initrd.img-\S+-generic} }
+      end
+    end
+
+    describe file('/boot/grub/menu.lst') do
+      before { skip 'until alicloud/aws/openstack stop clobbering the symlink with "update-grub"' }
+      it { should be_linked_to('./grub.cfg') }
+    end
+  end
+
+  context 'installed by image_install_grub_efi', {
+    exclude_on_alicloud: true,
+    exclude_on_aws: true,
+    exclude_on_cloudstack: true,
+    exclude_on_google: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+    exclude_on_azure: true,
+  } do
+    describe file('/boot/efi/EFI/grub/grub.cfg') do
+      it { should be_file }
+      its(:content) { should match 'set default="0"' }
+      its(:content) { should match ' selinux=0' }
+      its(:content) { should match ' cgroup_enable=memory swapaccount=1' }
+      its(:content) { should match ' console=ttyS0,115200n8' }
+      its(:content) { should match ' earlyprintk=ttyS0 rootdelay=300' }
+
+      it('should set the grub menu password (stig: V-38585)') { expect(subject.content).to match /password_pbkdf2 vcap/ }
+      it('should be of mode 600 (stig: V-38583)') { expect(subject).to be_mode(0600) }
+      it('should be owned by root (stig: V-38579)') { expect(subject).to be_owned_by('root') }
+      it('should be grouped into root (stig: V-38581)') { expect(subject.group).to eq('root') }
+      it('audits processes that start prior to auditd (CIS-8.1.3)') { expect(subject.content).to match ' audit=1' }
+    end
+
+    context 'for default kernel', exclude_on_fips: true do
+      describe file('/boot/efi/EFI/grub/grub.cfg') do
         it { should be_file }
         its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-generic root=UUID=\S* ro } }
         its(:content) { should match %r{initrd\t/boot/initrd.img-\S+-generic} }

--- a/bosh-stemcell/spec/support/stemcell_shared_examples.rb
+++ b/bosh-stemcell/spec/support/stemcell_shared_examples.rb
@@ -20,8 +20,25 @@ shared_examples_for 'All Stemcells' do
     end
   end
 
-  context 'ipv6 is disabled in the kernel' do
+  context 'ipv6 is disabled in the kernel', {
+    exclude_on_vsphere: true,
+  } do
     describe file('/boot/grub/grub.cfg') do
+      its(:content) { should match(/^\s+(kernel|linux)\s.*\sipv6\.disable=1\s.*$/) }
+    end
+  end
+
+  context 'ipv6 is disabled in the kernel on EFI', {
+    exclude_on_softlayer: true,
+    exclude_on_cloudstack: true,
+    exclude_on_vcloud: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+    exclude_on_azure: true,
+    exclude_on_aws: true,
+    exclude_on_google: true,
+  } do
+    describe file('/boot/efi/EFI/grub/grub.cfg') do
       its(:content) { should match(/^\s+(kernel|linux)\s.*\sipv6\.disable=1\s.*$/) }
     end
   end

--- a/ci/docker/os-image-stemcell-builder-jammy/Dockerfile
+++ b/ci/docker/os-image-stemcell-builder-jammy/Dockerfile
@@ -18,6 +18,7 @@ RUN \
     curl \
     debootstrap \
     dnsutils \
+    dosfstools \
     git \
     golang \
     jq \

--- a/stemcell_builder/stages/image_create_efi/apply.sh
+++ b/stemcell_builder/stages/image_create_efi/apply.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+
+disk_image=${work}/${stemcell_image_name}
+
+# image_create_disk_size is in MiB
+dd if=/dev/null of=${disk_image} bs=1M seek=${image_create_disk_size} 2> /dev/null
+parted --script ${disk_image} mklabel msdos
+parted --script ${disk_image} mkpart primary fat32 0% 49MiB
+parted --script ${disk_image} set 1 esp on
+parted --script ${disk_image} mkpart primary ext2 50MiB 100%
+
+# unmap the loop device in case it's already mapped
+timeout 100 bash -c "
+until kpartx -dv ${disk_image}; do
+  echo 'Waiting for loop device to be free'
+  echo 'Running lsof'
+  lsof ${disk_image}
+  sleep 1
+done
+"
+
+# Map partition in image to loopback
+device=$(losetup --show --find ${disk_image})
+add_on_exit "losetup --verbose --detach ${device}"
+
+device_partition_efi=$(kpartx -sav ${device} | cut -d" " -f3 | head -1)
+device_partition_root=$(kpartx -sav ${device} | cut -d" " -f3 | tail -1)
+add_on_exit "kpartx -dv ${device}"
+
+loopback_efi_dev="/dev/mapper/${device_partition_efi}"
+loopback_root_dev="/dev/mapper/${device_partition_root}"
+
+# Format the partitions
+mkfs.vfat ${loopback_efi_dev}
+mkfs.ext4 ${loopback_root_dev}
+
+# Mount partition
+image_mount_point=${work}/mnt
+
+mkdir -p ${image_mount_point}
+mount ${loopback_root_dev} ${image_mount_point}
+add_on_exit "umount ${image_mount_point}"
+
+mkdir -p ${image_mount_point}/boot/efi
+mount ${loopback_efi_dev} ${image_mount_point}/boot/efi
+add_on_exit "umount ${image_mount_point}/boot/efi"
+
+# Copy root, don't cross mount-points, skipping /boot/efi is okay; it's empty
+time rsync -aHA $chroot/ ${image_mount_point}

--- a/stemcell_builder/stages/image_create_efi/config.sh
+++ b/stemcell_builder/stages/image_create_efi/config.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_config.bash
+
+assert_available parted
+assert_available kpartx
+
+if [ -z "${image_create_disk_size:-}" ]
+then
+  image_create_disk_size=1225
+fi
+
+persist_value image_create_disk_size
+persist_value stemcell_image_name

--- a/stemcell_builder/stages/image_install_grub_efi/apply.sh
+++ b/stemcell_builder/stages/image_install_grub_efi/apply.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+
+disk_image=${work}/${stemcell_image_name}
+image_mount_point=${work}/mnt
+
+kpartx -dv ${disk_image}
+
+# note: if the above kpartx command fails, it's probably because the loopback device needs to be unmapped.
+# in that case, try this: sudo dmsetup remove loop0p1
+
+# Map partition in image to loopback
+device=$(losetup --show --find ${disk_image})
+add_on_exit "losetup --verbose --detach ${device}"
+
+device_partition_efi=$(kpartx -sav ${device} | cut -d" " -f3 | head -1)
+device_partition_root=$(kpartx -sav ${device} | cut -d" " -f3 | tail -1)
+add_on_exit "kpartx -dv ${device}"
+
+loopback_efi_dev="/dev/mapper/${device_partition_efi}"
+loopback_root_dev="/dev/mapper/${device_partition_root}"
+
+# Mount partition
+image_mount_point=${work}/mnt
+
+mkdir -p ${image_mount_point}
+mount ${loopback_root_dev} ${image_mount_point}
+add_on_exit "umount ${image_mount_point}"
+
+mkdir -p ${image_mount_point}/boot/efi
+mount ${loopback_efi_dev} ${image_mount_point}/boot/efi
+add_on_exit "umount ${image_mount_point}/boot/efi"
+
+# == Guide to variables in this script (all paths are defined relative to the real root dir, not the chroot)
+
+# work: the base working directory outside the chroot
+#      eg: /mnt/stemcells/aws/xen/centos/work/work
+# disk_image: path to the stemcell disk image
+#      eg: /mnt/stemcells/aws/xen/centos/work/work/aws-xen-centos.raw
+# device: path to the loopback devide mapped to the entire disk image
+#      eg: /dev/loop0
+# loopback_efi_dev: device node mapped to the EFI boot ("/boot/efi") partition in disk_image
+#      eg: /dev/mapper/loop0p1
+# loopback_root_dev: device node mapped to the root partition ("/") in disk_image
+#      eg: /dev/mapper/loop0p2
+# image_mount_point: place where loopback_dev is mounted as a filesystem
+#      eg: /mnt/stemcells/aws/xen/centos/work/work/mnt
+
+# Generate random password
+random_password=$(tr -dc A-Za-z0-9_ < /dev/urandom | head -c 16)
+
+touch ${image_mount_point}${device}
+mount --bind ${device} ${image_mount_point}${device}
+add_on_exit "umount ${image_mount_point}${device}"
+
+mkdir -p `dirname ${image_mount_point}${loopback_root_dev}`
+touch ${image_mount_point}${loopback_root_dev}
+mount --bind ${loopback_root_dev} ${image_mount_point}${loopback_root_dev}
+add_on_exit "umount ${image_mount_point}${loopback_root_dev}"
+
+mkdir -p `dirname ${image_mount_point}${loopback_efi_dev}`
+touch ${image_mount_point}${loopback_efi_dev}
+mount --bind ${loopback_efi_dev} ${image_mount_point}${loopback_efi_dev}
+add_on_exit "umount ${image_mount_point}${loopback_efi_dev}"
+
+# GRUB 2 needs /sys and /proc to do its job
+mount -t proc none ${image_mount_point}/proc
+add_on_exit "umount ${image_mount_point}/proc"
+
+mount -t sysfs none ${image_mount_point}/sys
+add_on_exit "umount ${image_mount_point}/sys"
+
+echo "(hd0) ${device}" > ${image_mount_point}/boot/grub/device.map
+
+# install bootsector into disk image file
+run_in_chroot ${image_mount_point} "grub-install --target=x86_64-efi --efi-directory=/boot/efi --boot-directory=/boot/efi/EFI --removable -v --no-floppy ${device}"
+
+grub_suffix=""
+case "${stemcell_infrastructure}" in
+aws)
+  grub_suffix="nvme_core.io_timeout=4294967295"
+  ;;
+cloudstack)
+  grub_suffix="console=hvc0"
+  ;;
+esac
+
+## TODO: investigate why we need this fix https://github.com/systemd/systemd/issues/13477
+# fixes the monit helper script for finding the net_cls group see line stages/bosh_monit/moint-access-helper.sh:16
+CGROUP_FIX="systemd.unified_cgroup_hierarchy=false"
+
+cat >${image_mount_point}/etc/default/grub <<EOF
+GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 ${grub_suffix} ${CGROUP_FIX}"
+EOF
+
+# we use a random password to prevent user from editing the boot menu
+pbkdf2_password=`run_in_chroot ${image_mount_point} "echo -e '${random_password}\n${random_password}' | grub-mkpasswd-pbkdf2 | grep -Eo 'grub.pbkdf2.sha512.*'"`
+echo "\
+cat << EOF
+set superusers=vcap
+password_pbkdf2 vcap $pbkdf2_password
+EOF" >> ${image_mount_point}/etc/grub.d/00_header
+
+# Setup menuentry
+sed -i -e 's/--class os/--class os --unrestricted/g' ${image_mount_point}/etc/grub.d/10_linux
+
+# assemble config file that is read by grub2 at boot time
+run_in_chroot ${image_mount_point} "GRUB_DISABLE_RECOVERY=true grub-mkconfig -o /boot/efi/EFI/grub/grub.cfg"
+
+# Figure out uuid of partition
+uuid_efi=$(blkid -c /dev/null -sUUID -ovalue ${loopback_efi_dev})
+uuid_root=$(blkid -c /dev/null -sUUID -ovalue ${loopback_root_dev})
+kernel_version=$(basename $(ls -rt ${image_mount_point}/boot/vmlinuz-* |tail -1) |cut -f2-8 -d'-')
+initrd_file="initrd.img-${kernel_version}"
+os_name=$(source ${image_mount_point}/etc/lsb-release ; echo -n ${DISTRIB_DESCRIPTION})
+
+# set the correct root filesystem; use the ext2 filesystem's UUID
+sed -i s%root=${loopback_root_dev}%root=UUID=${uuid_root}%g ${image_mount_point}/boot/efi/EFI/grub/grub.cfg
+rm ${image_mount_point}/boot/grub/device.map
+
+cat > ${image_mount_point}/etc/fstab <<FSTAB
+# /etc/fstab Created by BOSH Stemcell Builder
+UUID=${uuid_efi} /boot/efi vfat umask=0177 1 1
+UUID=${uuid_root} / ext4 defaults 1 1
+FSTAB
+

--- a/stemcell_builder/stages/image_install_grub_efi/config.sh
+++ b/stemcell_builder/stages/image_install_grub_efi/config.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_config.bash
+
+persist_value stemcell_image_name
+persist_value stemcell_infrastructure

--- a/stemcell_builder/stages/image_ovf_vmx/apply.sh
+++ b/stemcell_builder/stages/image_ovf_vmx/apply.sh
@@ -55,7 +55,8 @@ powerType.powerOff = "preset"
 powerType.powerOn = "preset"
 powerType.suspend = "preset"
 powerType.reset = "preset"
-
+firmware = "efi"
+chipset.motherboardLayout = "acpi"
 displayName = "$vm_hostname $vm_arch"
 
 numvcpus = "$vm_cpus"

--- a/stemcell_builder/stages/sbom_create/apply.sh
+++ b/stemcell_builder/stages/sbom_create/apply.sh
@@ -21,10 +21,10 @@ done
 device=$(losetup --show --find ${disk_image})
 add_on_exit "losetup --verbose --detach ${device}"
 
-device_partition=$(kpartx -sav ${device} | grep "^add" | cut -d" " -f3)
+device_partition_root=$(kpartx -sav ${device} | cut -d" " -f3 | tail -1)
 add_on_exit "kpartx -dv ${device}"
 
-loopback_dev="/dev/mapper/${device_partition}"
+loopback_dev="/dev/mapper/${device_partition_root}"
 
 # Mount partition
 image_mount_point=${work}/mnt

--- a/stemcell_builder/stages/system_grub/apply.sh
+++ b/stemcell_builder/stages/system_grub/apply.sh
@@ -14,7 +14,7 @@ else
 fi
 
 if pkg_exists $preferred; then
-  pkg_mgr install $preferred
+  pkg_mgr install $preferred grub-efi-amd64-bin
 elif pkg_exists $fallback; then
   pkg_mgr install $fallback
 else


### PR DESCRIPTION
This is for vSphere stemcells can to access > 16 GiB GPUs

Booting from an EFI partition is necessary to access and utilize
GPUs with more than 16 GB of memory because UEFI provides the
advanced memory addressing, compatibility, and initialization
capabilities required for such hardware. The older BIOS/MBR
system cannot efficiently handle the requirements of modern
high-capacity GPUs.