### PR TITLE
Updates validation test for new GRUB conf location

### DIFF
--- a/bosh-stemcell/spec/stemcells/fips_spec.rb
+++ b/bosh-stemcell/spec/stemcells/fips_spec.rb
@@ -36,7 +36,7 @@ describe 'FIPS Stemcell', os_image: true do
   end
 
   context 'installed by image_install_grub for fips kernel' do
-    describe file('/boot/grub/grub.cfg') do
+    describe file('/boot/efi/EFI/grub/grub.cfg') do
       it { should be_file }
       its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-fips root=UUID=\S* ro } }
       if use_iaas_kernel


### PR DESCRIPTION
This commit updates the GRUB bootloader location and contents verification test for the FIPS stemcell creator to look for the file in a new location.

This change to the location of the GRUB config was probably introduced in commit b67cf289f84757bc708be45aeb1235462ef7b373.

This commit attempts to correct the following error in CI:

=====
```
Failures:

  1) FIPS Stemcell installed by image_install_grub for fips kernel /boot/grub/grub.cfg is expected to be file
     Failure/Error: it { should be_file }
       expected `#<ShelloutTypes::File:0x00007fd51bdd6718 @path="/boot/grub/grub.cfg", @chroot=#<ShelloutTypes::Chroot:0x00007fd51bdd6740>>.file?` to be truthy, got false
     # ./spec/stemcells/fips_spec.rb:40:in `block (4 levels) in <top (required)>'

  2) FIPS Stemcell installed by image_install_grub for fips kernel /boot/grub/grub.cfg content
     Failure/Error: raise RuntimeError, stderr if status != 0

     RuntimeError:
       cat: /boot/grub/grub.cfg: No such file or directory
     # ./lib/shellout_types/file.rb:42:in `content'
     # ./spec/stemcells/fips_spec.rb:41:in `block (4 levels) in <top (required)>'

  3) FIPS Stemcell installed by image_install_grub for fips kernel /boot/grub/grub.cfg content
     Failure/Error: raise RuntimeError, stderr if status != 0

     RuntimeError:
       cat: /boot/grub/grub.cfg: No such file or directory
     # ./lib/shellout_types/file.rb:42:in `content'
     # ./spec/stemcells/fips_spec.rb:45:in `block (4 levels) in <top (required)>'
```