### PR TITLE
Handles EFI stemcells in mount-image helper

### DIFF
--- a/scripts/repack-helpers/mount-image.sh
+++ b/scripts/repack-helpers/mount-image.sh
@@ -8,6 +8,9 @@ fi
 image_path=$(cat)
 chroot=$(mktemp -d)
 
-device=$(kpartx -sav ${image_path%%/disk.raw}/disk.raw | grep '^add' | cut -d' ' -f3)
+## NOTE: Certain stemcells now have EFI support. To do this, they have an initial, FAT32 partition at the head of the disk and
+##       the normal stemcell data partition at the tail. So, we're now assuming that if there are multiple partitions in a
+##       disk image, that only the last one in the list is relevant.
+device=$(kpartx -sav ${image_path%%/disk.raw}/disk.raw | grep '^add' | tail -n1 | cut -d' ' -f3)
 mount -o loop,rw "/dev/mapper/${device}" ${chroot}
 echo $chroot


### PR DESCRIPTION
This commit is the simplest-possible way to deal with the new stemcells that have an EFI partition at the front.

Historically, stemcells have had a single partition. Now, with EFI support, they have a FAT32 partition at the front of the disk, and the regular stemcell partition at the back.

If we ever have disks where we need to care about more than the last partition on the disk, then this code will need to be reworked.

Resolves the following error when attempting to mount a recent vSphere stemcell:

========
```
+ qemu-img convert /tmp/tmp.e7ztdeOVTP/image-disk1.vmdk /tmp/tmp.KoBkwEKwxd/disk.raw
+ echo /tmp/tmp.KoBkwEKwxd/disk.raw
+ extracted_image_path=/tmp/tmp.KoBkwEKwxd/disk.raw
+ [[ ./stemcell/bosh-stemcell-1.465-vsphere-esxi-ubuntu-jammy-go_agent.tgz =~ warden-boshlite ]] ++ ./bosh-linux-stemcell-builder/scripts/repack-helpers/mount-image.sh
+ '[' -t 0 ']' ++ cat
+ image_path=/tmp/tmp.KoBkwEKwxd/disk.raw ++ mktemp -d
+ chroot=/tmp/tmp.k8j1Y84KXx ++ kpartx -sav /tmp/tmp.KoBkwEKwxd/disk.raw
++ grep '^add'
++ cut '-d ' -f3
+ device='loop9p1 loop9p2'
+ mount -o loop,rw '/dev/mapper/loop9p1 loop9p2' /tmp/tmp.k8j1Y84KXx
mount: /dev/mapper/loop9p1
loop9p2: failed to setup loop device: No such file or directory
+ mounted_image_path=
+ on_exit
+ echo 'Running 4 on_exit items...' Running 4 on_exit items...
```