### PR TITLE
Add spec helper for grub.cfg path

### DIFF
--- a/bosh-stemcell/spec/spec_helper.rb
+++ b/bosh-stemcell/spec/spec_helper.rb
@@ -8,7 +8,15 @@ Dir.glob(File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require(f)
 
 # do not truncate array comparison
 RSpec.configure do |rspec|
-    rspec.expect_with :rspec do |c|
-      c.max_formatted_output_length = nil
-    end
+  rspec.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
   end
+end
+
+def grub_cfg_path
+  if ENV['STEMCELL_INFRASTRUCTURE'] == 'vsphere'
+    '/boot/efi/EFI/grub/grub.cfg'
+  else
+    '/boot/grub/grub.cfg'
+  end
+end

--- a/bosh-stemcell/spec/stemcells/aws_spec.rb
+++ b/bosh-stemcell/spec/stemcells/aws_spec.rb
@@ -18,7 +18,7 @@ describe 'AWS Stemcell', stemcell_image: true do
   end
 
   context 'installed by image_install_grub' do
-    describe file('/boot/grub/grub.cfg') do
+    describe file(grub_cfg_path) do
       it { should be_file }
       its(:content) { should match ' nvme_core.io_timeout=4294967295' }
     end

--- a/bosh-stemcell/spec/stemcells/fips_spec.rb
+++ b/bosh-stemcell/spec/stemcells/fips_spec.rb
@@ -36,13 +36,7 @@ describe 'FIPS Stemcell', os_image: true do
   end
 
   context 'installed by image_install_grub for fips kernel' do
-    grub_file = if ENV['STEMCELL_INFRASTRUCTURE'] == 'vsphere'
-                  '/boot/efi/EFI/grub/grub.cfg'
-                else
-                  '/boot/grub/grub.cfg'
-                end
-
-    describe file(grub_file) do
+    describe file(grub_cfg_path) do
       it { should be_file }
       its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-fips root=UUID=\S* ro } }
       if use_iaas_kernel

--- a/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
@@ -23,11 +23,11 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
         exclude_on_azure: true,
         exclude_on_openstack: true,
     } do
-      describe file('/boot/grub/grub.cfg') do
+      describe file(grub_cfg_path) do
         its(:content) { should match ' console=hvc0' }
       end
     end
-    describe file('/boot/grub/grub.cfg') do
+    describe file(grub_cfg_path) do
       it { should be_file }
       its(:content) { should match 'set default="0"' }
       its(:content) { should match(/^set root=\(hd0,0\)$/) }
@@ -44,7 +44,7 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
     end
 
     context 'for default kernel', exclude_on_fips: true do
-      describe file('/boot/grub/grub.cfg') do
+      describe file(grub_cfg_path) do
         it { should be_file }
         its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-generic root=UUID=\S* ro } }
         its(:content) { should match %r{initrd\t/boot/initrd.img-\S+-generic} }
@@ -107,7 +107,7 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
       exclude_on_openstack: true,
       exclude_on_azure: true,
   } do
-    describe file('/boot/grub/grub.cfg') do
+    describe file(grub_cfg_path) do
       it { should be_file }
       its(:content) { should match 'set default="0"' }
       its(:content) { should match(/^set root=\(hd0,2\)$/) }

--- a/bosh-stemcell/spec/support/stemcell_shared_examples.rb
+++ b/bosh-stemcell/spec/support/stemcell_shared_examples.rb
@@ -24,7 +24,7 @@ shared_examples_for 'All Stemcells' do
     exclude_on_vsphere: true,
     exclude_on_vcloud: true,
   } do
-    describe file('/boot/grub/grub.cfg') do
+    describe file(grub_cfg_path) do
       its(:content) { should match(/^\s+(kernel|linux)\s.*\sipv6\.disable=1\s.*$/) }
     end
   end


### PR DESCRIPTION
This is in a different place on EFI vsphere jammy stemcells than on any other iaas or stemcell line.