### PR TITLE
Do not exclude grub tests on fips

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
@@ -65,7 +65,6 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
     exclude_on_warden: true,
     exclude_on_openstack: true,
     exclude_on_azure: true,
-    exclude_on_fips: true,
   } do
     describe file('/boot/efi/EFI/grub/grub.cfg') do
       it { should be_file }


### PR DESCRIPTION
Doing so will fail the STIG and CIS specs:

Failures:
```
  1) CIS test case verification For all infrastructure except Azure and Cloudstack confirms that all CIS test cases ran
     Failure/Error: expect($cis_test_cases.to_a).to match_array(base_cis_test_cases + ['CIS-2.24'])

       expected collection contained:  ["CIS-10.2", "CIS-11.1", "CIS-2.18", "CIS-2.19", "CIS-2.20", "CIS-2.21", "CIS-2.22", "CIS-2.23", "CIS-2.24", "CIS-3.2.4", "CIS-4.1", "CIS-4.1.6", "CIS-4.1.7", "CIS-5.2.12", "CIS-5.2.13", "CIS-7.2.5", "CIS-7.2.6", "CIS-7.2.7", "CIS-7.3.1", "CIS-7.3.2", "CIS-7.5.3", "CIS-8.1.10", "CIS-8.1.11", "CIS-8.1.12", "CIS-8.1.13", "CIS-8.1.14", "CIS-8.1.15", "CIS-8.1.16", "CIS-8.1.18", "CIS-8.1.3", "CIS-8.1.4", "CIS-8.1.5", "CIS-8.1.8", "CIS-8.1.9", "CIS-9.1.2", "CIS-9.1.3", "CIS-9.1.4", "CIS-9.1.5", "CIS-9.1.6", "CIS-9.1.7", "CIS-9.1.8", "CIS-9.2.1", "CIS-9.4", "CIS-9.5"]
       actual collection contained:    ["CIS-10.2", "CIS-11.1", "CIS-2.18", "CIS-2.19", "CIS-2.20", "CIS-2.21", "CIS-2.22", "CIS-2.23", "CIS-2.24", "CIS-3.2.4", "CIS-4.1", "CIS-4.1.6", "CIS-4.1.7", "CIS-5.2.12", "CIS-5.2.13", "CIS-7.2.5", "CIS-7.2.6", "CIS-7.2.7", "CIS-7.3.1", "CIS-7.3.2", "CIS-7.5.3", "CIS-8.1.10", "CIS-8.1.11", "CIS-8.1.12", "CIS-8.1.13", "CIS-8.1.14", "CIS-8.1.15", "CIS-8.1.16", "CIS-8.1.18", "CIS-8.1.4", "CIS-8.1.5", "CIS-8.1.8", "CIS-8.1.9", "CIS-9.1.2", "CIS-9.1.3", "CIS-9.1.4", "CIS-9.1.5", "CIS-9.1.6", "CIS-9.1.7", "CIS-9.1.8", "CIS-9.2.1", "CIS-9.4", "CIS-9.5"]
       the missing elements were:      ["CIS-8.1.3"]
     # ./spec/stemcells/cis_spec.rb:54:in `block (3 levels) in <top (required)>'

  2) Stig test case verification confirms all stig test cases ran
     Failure/Error: expect($stig_test_cases.to_a).to match_array expected_stig_test_cases

       expected collection contained:  ["V-38443", "V-38444", "V-38445", "V-38446", "V-38448", "V-38449", "V-38450", "V-38451", "V-38457", "V-38458", "V-38459", "V-38461", "V-38462", "V-38464", "V-38465", "V-38466", "V-38468", "V-38469", "V-38470", "V-38472", "V-38475", "V-38476", "V-38477", "V-38483", "V-38484", "V-38490", "V-38491", "V-38492", "V-38493", "V-38495", "V-38496", "V-38497", "V-38498", "V-38499", "V-38500", "V-38502", "V-38503", "V-38504", "V-38511", "V-38514", "V-38515", "V-38517", "V-38518", "V-38519", "V-38523", "V-38524", "V-38526", "V-38529", "V-38532", "V-38539", "V-38542", "V-38544", "V-38546", "V-38548", "V-38551", "V-38553", "V-38573", "V-38574", "V-38576", "V-38579", "V-38580", "V-38581", "V-38582", "V-38583", "V-38585", "V-38587", "V-38589", "V-38591", "V-38593", "V-38594", "V-38596", "V-38597", "V-38598", "V-38599", "V-38600", "V-38601", "V-38602", "V-38603", "V-38604", "V-38605", "V-38606", "V-38607", "V-38609", "V-38611", "V-38612", "V-38613", "V-38614", "V-38615", "V-38616", "V-38617", "V-38619", "V-38620", "V-38621", "V-38622", "V-38623", "V-38628", "V-38629", "V-38630", "V-38631", "V-38632", "V-38633", "V-38634", "V-38636", "V-38637", "V-38638", "V-38643", "V-38652", "V-38653", "V-38654", "V-38658", "V-38660", "V-38663", "V-38664", "V-38665", "V-38668", "V-38671", "V-38674", "V-38678", "V-38682", "V-38691", "V-38701", "V-43150", "V-51875", "V-54381", "V-58901", "V-75689", "V-75707", "V-75757", "V-75765", "V-75779", "V-75785", "V-75837", "V-75851", "V-75865", "V-80969"]
       actual collection contained:    ["V-38443", "V-38444", "V-38445", "V-38446", "V-38448", "V-38449", "V-38450", "V-38451", "V-38457", "V-38458", "V-38459", "V-38461", "V-38462", "V-38464", "V-38465", "V-38466", "V-38468", "V-38469", "V-38470", "V-38472", "V-38475", "V-38476", "V-38477", "V-38483", "V-38484", "V-38490", "V-38491", "V-38492", "V-38493", "V-38495", "V-38496", "V-38497", "V-38498", "V-38499", "V-38500", "V-38502", "V-38503", "V-38504", "V-38511", "V-38514", "V-38515", "V-38517", "V-38518", "V-38519", "V-38523", "V-38524", "V-38526", "V-38529", "V-38532", "V-38539", "V-38542", "V-38544", "V-38546", "V-38548", "V-38551", "V-38553", "V-38573", "V-38574", "V-38576", "V-38580", "V-38582", "V-38587", "V-38589", "V-38591", "V-38593", "V-38594", "V-38596", "V-38597", "V-38598", "V-38599", "V-38600", "V-38601", "V-38602", "V-38603", "V-38604", "V-38605", "V-38606", "V-38607", "V-38609", "V-38611", "V-38612", "V-38613", "V-38614", "V-38615", "V-38616", "V-38617", "V-38619", "V-38620", "V-38621", "V-38622", "V-38623", "V-38628", "V-38629", "V-38630", "V-38631", "V-38632", "V-38633", "V-38634", "V-38636", "V-38637", "V-38638", "V-38643", "V-38652", "V-38653", "V-38654", "V-38658", "V-38660", "V-38663", "V-38664", "V-38665", "V-38668", "V-38671", "V-38674", "V-38678", "V-38682", "V-38691", "V-38701", "V-43150", "V-51875", "V-54381", "V-58901", "V-75689", "V-75707", "V-75757", "V-75765", "V-75779", "V-75785", "V-75837", "V-75851", "V-75865", "V-80969"]
       the missing elements were:      ["V-38579", "V-38581", "V-38583", "V-38585"]
     # ./spec/stemcells/stig_spec.rb:157:in `block (2 levels) in <top (required)>'
```