### PR TITLE
fix: determine grub.cfg location based on infrastructure

### DIFF
--- a/bosh-stemcell/spec/stemcells/fips_spec.rb
+++ b/bosh-stemcell/spec/stemcells/fips_spec.rb
@@ -36,7 +36,8 @@ describe 'FIPS Stemcell', os_image: true do
   end
 
   context 'installed by image_install_grub for fips kernel' do
-    describe file('/boot/efi/EFI/grub/grub.cfg') do
+    infrastructure = ENV['STEMCELL_INFRASTRUCTURE']
+    describe file(infrastructure == 'vsphere' ? '/boot/efi/EFI/grub/grub.cfg' : '/boot/grub/grub.cfg') do
       it { should be_file }
       its(:content) { should match %r{linux\t/boot/vmlinuz-\S+-fips root=UUID=\S* ro } }
       if use_iaas_kernel


### PR DESCRIPTION
The change in location of grub.cfg only impacts vsphere however the test change (https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/357) made no distinction. This commit uses the infrastructure to determine which location should be checked in test.