### PR TITLE
Revert "retries for firstboot and let ssh.service depends on firstboot_done file"

### DIFF
--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -100,7 +100,3 @@ then
 else
   sudo echo "ENABLED=0" >$chroot/etc/default/motd-news
 fi
-
-# add drop-in for sshd service so it will only starts after first boot has been succefully run
-mkdir -p $chroot/lib/systemd/system/ssh.service.d
-cp $assets_dir/10-ssh-firstboot-done.conf $chroot/lib/systemd/system/ssh.service.d/10-ssh-firstboot-done.conf

--- a/stemcell_builder/stages/base_ssh/assets/10-ssh-firstboot-done.conf
+++ b/stemcell_builder/stages/base_ssh/assets/10-ssh-firstboot-done.conf
@@ -1,2 +1,0 @@
-[Unit]
-ConditionPathExists=/root/firstboot_done

--- a/stemcell_builder/stages/base_ubuntu_firstboot/assets/etc/rc.local
+++ b/stemcell_builder/stages/base_ubuntu_firstboot/assets/etc/rc.local
@@ -2,21 +2,8 @@
 #execute firstboot.sh only once
 if [ ! -e /root/firstboot_done ]; then
     if [ -e /root/firstboot.sh ]; then
-        MAX_RETRIES=5
-        COUNT=0
-        while [ $COUNT -lt $MAX_RETRIES ]; do
-            /root/firstboot.sh
-            if [ $? -eq 0 ]; then
-                touch /root/firstboot_done
-                break
-            fi
-            COUNT=$((COUNT+1))
-            sleep 1
-        done
-        if [ $COUNT -eq $MAX_RETRIES ]; then
-            echo "Max retries reached. Exiting..."
-            exit 1
-        fi
+        /root/firstboot.sh
     fi
+    touch /root/firstboot_done
 fi
 exit 0


### PR DESCRIPTION
Reverts cloudfoundry/bosh-linux-stemcell-builder#356

We are reverting this because it appears to cause failures when running BATS. BATS is unable to use `bosh ssh` to SSH into the deployed VM. We tried replicating this by manually downloading and deploying the stemcell, but were unable to reproduce the failure.

See this failed build for more details:
https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/stemcells-ubuntu-jammy/jobs/bats-master/builds/147