### PR TITLE
Lower ClientAliveInterval for ssh

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -279,8 +279,8 @@ shared_examples_for 'every OS image' do
       expect(sshd_config.content).to match(/^IgnoreRhosts yes$/)
     end
 
-    it 'sets ClientAliveInterval to 900 seconds (CIS-5.2.12)' do
-      expect(sshd_config.content).to match(/^ClientAliveInterval 300$/)
+    it 'sets ClientAliveInterval to 180 seconds (CIS-5.2.12)' do
+      expect(sshd_config.content).to match(/^ClientAliveInterval 180$/)
     end
 
     it 'sets LoginGraceTime to 60 seconds (CIS-5.2.13)' do

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -40,7 +40,7 @@ sed "/^ *IgnoreRhosts/d" -i $chroot/etc/ssh/sshd_config
 echo 'IgnoreRhosts yes' >> $chroot/etc/ssh/sshd_config
 
 sed "/^ *ClientAliveInterval/d" -i $chroot/etc/ssh/sshd_config
-echo 'ClientAliveInterval 300' >> $chroot/etc/ssh/sshd_config
+echo 'ClientAliveInterval 180' >> $chroot/etc/ssh/sshd_config
 
 sed "/^ *LoginGraceTime/d" -i $chroot/etc/ssh/sshd_config
 echo 'LoginGraceTime 60' >> $chroot/etc/ssh/sshd_config

--- a/stemcell_builder/stages/system_azure_init/assets/etc/waagent/waagent.conf
+++ b/stemcell_builder/stages/system_azure_init/assets/etc/waagent/waagent.conf
@@ -85,8 +85,8 @@ OS.OpensslPath=None
 # Set the path to SSH keys and configuration files
 OS.SshDir=/etc/ssh
 
-# Set /etc/ssh/sshd_config ClientAliveInterval to 900
-OS.SshClientAliveInterval=900 # NON-DEFAULT, works around azure TCP NAT tables timeouts
+# Set /etc/ssh/sshd_config ClientAliveInterval to 180
+OS.SshClientAliveInterval=180
 
 # If set, agent will use proxy server to access internet
 #HttpProxy.Host=None


### PR DESCRIPTION
The Azure Marketplace requires that images have set ClientAliveInterval to between 30 and 235, with a recommended value of 180. It seems safe to update the value for all IaaSes, as it simply controls how long to wait before the sshd server sends a message to a quiet client asking for a response.

For more information, see:
https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-marketplace-images#linux-and-open-source-os-images