### PR TITLE
Fix quoting on stemcell version

### DIFF
--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/auditd/manifest.yml
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/auditd/manifest.yml
@@ -8,7 +8,7 @@ releases:
 stemcells:
 - alias: default
   os: ((os_name))
-  version: ((stemcell_version))
+  version: "((stemcell_version))"
 
 update:
   canaries: 1

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/ipv6basic/manifest.yml
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/ipv6basic/manifest.yml
@@ -6,7 +6,7 @@ releases: []
 stemcells:
 - alias: default
   os: ((os_name))
-  version: ((stemcell_version))
+  version: "((stemcell_version))"
 
 update:
   canaries: 1

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/manifest.yml
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/smoke/manifest.yml
@@ -8,7 +8,7 @@ releases:
 stemcells:
 - alias: default
   os: ((os_name))
-  version: ((stemcell_version))
+  version: "((stemcell_version))"
 
 update:
   canaries: 1

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/syslogrelease/manifest.yml
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv4director/syslogrelease/manifest.yml
@@ -8,7 +8,7 @@ releases:
 stemcells:
 - alias: default
   os: ((os_name))
-  version: ((stemcell_version))
+  version: "((stemcell_version))"
 
 update:
   canaries: 1

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv6director/ipv6full/manifest.yml
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/ipv6director/ipv6full/manifest.yml
@@ -6,7 +6,7 @@ releases: []
 stemcells:
 - alias: default
   os: ((os_name))
-  version: ((stemcell_version))
+  version: "((stemcell_version))"
 
 update:
   canaries: 1


### PR DESCRIPTION
Trying to deploy a 1.530 version of Jammy was searching for a 1.53 version instead, likely due to YAML parsing assuming it was a float and not a string.