### PR TITLE
fix for jammy cis rule 1.6.1.2

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_jammy_spec.rb
@@ -35,6 +35,7 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
       its(:content) { should match ' cgroup_enable=memory swapaccount=1' }
       its(:content) { should match ' console=ttyS0,115200n8' }
       its(:content) { should match ' earlyprintk=ttyS0 rootdelay=300' }
+      its(:content) { should match ' apparmor=1 security=apparmor' }
 
       it('should set the grub menu password (stig: V-38585)') { expect(subject.content).to match /password_pbkdf2 vcap/ }
       it('should be of mode 600 (stig: V-38583)') { expect(subject).to be_mode(0600) }
@@ -73,6 +74,7 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
       its(:content) { should match ' cgroup_enable=memory swapaccount=1' }
       its(:content) { should match ' console=ttyS0,115200n8' }
       its(:content) { should match ' earlyprintk=ttyS0 rootdelay=300' }
+      its(:content) { should match ' apparmor=1 security=apparmor' }
 
       it('should set the grub menu password (stig: V-38585)') { expect(subject.content).to match /password_pbkdf2 vcap/ }
       it('should be of mode 600 (stig: V-38583)') { expect(subject).to be_mode(0600) }
@@ -116,6 +118,7 @@ describe 'Ubuntu 22.04 stemcell image', stemcell_image: true do
       its(:content) { should match ' console=ttyS0,115200n8' }
       its(:content) { should match ' earlyprintk=ttyS0 rootdelay=300' }
       its(:content) { should match %r{initrd\t/initrd.img-\S+-generic} }
+      its(:content) { should match ' apparmor=1 security=apparmor' }
 
       it('should set the grub menu password (stig: V-38585)') { expect(subject.content).to match /password_pbkdf2 vcap/ }
       it('should be of mode 600 (stig: V-38583)') { expect(subject).to be_mode(0600) }

--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -89,7 +89,7 @@ esac
 CGROUP_FIX="systemd.unified_cgroup_hierarchy=false"
 
 cat >${image_mount_point}/etc/default/grub <<EOF
-GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 ${grub_suffix} ${CGROUP_FIX}"
+GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 apparmor=1 security=apparmor ${grub_suffix} ${CGROUP_FIX}"
 EOF
 
 # we use a random password to prevent user from editing the boot menu

--- a/stemcell_builder/stages/image_install_grub_efi/apply.sh
+++ b/stemcell_builder/stages/image_install_grub_efi/apply.sh
@@ -94,7 +94,7 @@ esac
 CGROUP_FIX="systemd.unified_cgroup_hierarchy=false"
 
 cat >${image_mount_point}/etc/default/grub <<EOF
-GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 ${grub_suffix} ${CGROUP_FIX}"
+GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 apparmor=1 security=apparmor ${grub_suffix} ${CGROUP_FIX}"
 EOF
 
 # we use a random password to prevent user from editing the boot menu

--- a/stemcell_builder/stages/image_install_grub_softlayer_two_partitions/apply.sh
+++ b/stemcell_builder/stages/image_install_grub_softlayer_two_partitions/apply.sh
@@ -84,7 +84,7 @@ run_in_chroot ${image_mount_point} "grub-install -v --no-floppy --grub-mkdevicem
 # Enable password-less booting in openSUSE, only editing the boot menu needs to be restricted
 run_in_chroot ${image_mount_point} "sed -i 's/CLASS=\\\"--class gnu-linux --class gnu --class os\\\"/CLASS=\\\"--class gnu-linux --class gnu --class os --unrestricted\\\"/' /etc/grub.d/10_linux"
 cat >${image_mount_point}/etc/default/grub <<EOF
-GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1"
+GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 apparmor=1 security=apparmor"
 EOF
 
 # we use a random password to prevent user from editing the boot menu


### PR DESCRIPTION
This pr enables apparmor at boot time

CIS reference

## 1.6.1.2 Ensure AppArmor is enabled in the bootloader configuration (Automated)

### Profile Applicability:
- Level 1 - Server
- Level 1 - Workstation

### Description:
Configure AppArmor to be enabled at boot time and verify that it has not been overwritten by the bootloader boot parameters.
Note: This recommendation is designed around the grub bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings.

### Rationale:
AppArmor must be enabled at boot time in your bootloader configuration to ensure that the controls it provides are not overridden.

### Audit:
Run the following commands to verify that all linux lines have the `apparmor=1` and `security=apparmor` parameters set: 

`# grep "^\s*linux" /boot/grub/grub.cfg | grep -v "apparmor=1"`

Nothing should be returned 

`# grep "^\s*linux" /boot/grub/grub.cfg | grep -v "security=apparmor"`

Nothing should be returned

### Remediation:
Edit `/etc/default/grub` and add the `apparmor=1` and `security=apparmor` parameters to the `GRUB_CMDLINE_LINUX=` line `GRUB_CMDLINE_LINUX="apparmor=1 security=apparmor"`

Run the following command to update the grub2 configuration: 

`# update-grub`
