### PR TITLE
Restore default apt sources once stemcell is built

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -263,6 +263,7 @@ module Bosh::Stemcell
     def finish_stemcell_stages
       [
         :bosh_package_list,
+        :restore_apt_sources,
       ]
     end
 

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -96,6 +96,7 @@ module Bosh::Stemcell
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
+            :restore_apt_sources,
           ]
         }
         let(:aws_package_stemcell_stages) {
@@ -127,6 +128,7 @@ module Bosh::Stemcell
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
+            :restore_apt_sources,
           ]
         }
 
@@ -160,6 +162,7 @@ module Bosh::Stemcell
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
+            :restore_apt_sources,
           ]
         }
 
@@ -196,6 +199,7 @@ module Bosh::Stemcell
               :image_install_grub,
               :sbom_create,
               :bosh_package_list,
+              :restore_apt_sources,
             ]
           )
           expect(stage_collection.package_stemcell_stages('qcow2')).to eq(
@@ -227,6 +231,7 @@ module Bosh::Stemcell
               :image_install_grub,
               :sbom_create,
               :bosh_package_list,
+              :restore_apt_sources,
             ]
           )
           expect(stage_collection.package_stemcell_stages('qcow2')).to eq(
@@ -257,6 +262,7 @@ module Bosh::Stemcell
               :image_install_grub_efi,
               :sbom_create,
               :bosh_package_list,
+              :restore_apt_sources,
             ]
           )
           expect(stage_collection.package_stemcell_stages('ovf')).to eq(vmware_package_stemcell_steps)
@@ -285,6 +291,7 @@ module Bosh::Stemcell
                 :image_install_grub_efi,
                 :sbom_create,
                 :bosh_package_list,
+                :restore_apt_sources,
             ]
             )
             expect(stage_collection.package_stemcell_stages('ovf')).to eq(vmware_package_stemcell_steps)
@@ -310,6 +317,7 @@ module Bosh::Stemcell
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
+            :restore_apt_sources,
           ]
         }
 
@@ -348,7 +356,8 @@ module Bosh::Stemcell
                 :bosh_clean_ssh,
                 :image_create_softlayer_two_partitions,
                 :image_install_grub_softlayer_two_partitions,
-                :bosh_package_list
+                :bosh_package_list,
+                :restore_apt_sources,
               ]
             )
             expect(stage_collection.package_stemcell_stages('ovf')).to eq(vmware_package_stemcell_steps)
@@ -368,7 +377,8 @@ module Bosh::Stemcell
             :image_create,
             :image_install_grub,
             :sbom_create,
-            :bosh_package_list
+            :bosh_package_list,
+            :restore_apt_sources,
           ]
         }
         let(:package_stemcell_stages) {

--- a/stemcell_builder/stages/restore_apt_sources/apply.sh
+++ b/stemcell_builder/stages/restore_apt_sources/apply.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+
+mount --bind /sys "$chroot/sys"
+add_on_exit "umount $chroot/sys"
+
+cat > "$chroot/etc/apt/sources.list" <<EOS
+deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe multiverse
+deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe multiverse
+deb http://security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe multiverse
+EOS


### PR DESCRIPTION
We use the snapshot.ubuntu.com sources for build repeatability, but for products that are built on top of stemcells, we want to be able to get the latest updates to packages.

This adds a stage called "restore_apt_sources" that runs after the stemcell is constructed.