### PR TITLE
change pam_lastlog for pam_faillock + remove adiscon rsyslog ppa

### DIFF
--- a/bosh-stemcell/spec/os_image/ubuntu_noble_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_noble_spec.rb
@@ -304,7 +304,7 @@ EOF
 
   context 'display the number of unsuccessful logon/access attempts since the last successful logon/access (stig: V-51875)' do
     describe file('/etc/pam.d/common-password') do
-      its(:content) { should match /session\trequired\t\t\tpam_lastlog\.so showfailed/ }
+      its(:content) { should match /session\trequired\t\t\tpam_faillock\.so showfailed/ }
     end
   end
 

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -16,7 +16,7 @@ cmake uuid-dev libgcrypt-dev ca-certificates \
 scsitools mg htop module-assistant debhelper runit parted \
 cloud-guest-utils anacron software-properties-common \
 xfsprogs gdisk chrony dbus nvme-cli rng-tools fdisk \
-ethtool libpam-pwquality gpg-agent libcurl4 libcurl4-openssl-dev resolvconf net-tools ifupdown"
+ethtool libpam-modules libpam-pwquality gpg-agent libcurl4 libcurl4-openssl-dev resolvconf net-tools ifupdown"
 
 pkg_mgr purge netplan.io
 run_in_chroot $chroot "

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -31,9 +31,6 @@ run_in_chroot "${chroot}" "systemctl enable systemd-networkd-resolvconf-update.s
 
 pkg_mgr install $debs
 
-# NOBLE_TODO: adiscon repo does not have noble packages yet
-# run_in_chroot $chroot "add-apt-repository ppa:adiscon/v8-stable"
-# pkg_mgr install "rsyslog rsyslog-gnutls rsyslog-openssl rsyslog-mmjsonparse rsyslog-mmnormalize rsyslog-relp"
 pkg_mgr install "rsyslog rsyslog-gnutls rsyslog-openssl rsyslog-relp"
 
 run_in_chroot "${chroot}" "systemctl enable systemd-logind"

--- a/stemcell_builder/stages/password_policies/assets/ubuntu/common-password.patch
+++ b/stemcell_builder/stages/password_policies/assets/ubuntu/common-password.patch
@@ -13,5 +13,5 @@
  # since the modules above will each just jump around
  password	required			pam_permit.so
  # and here are more per-package modules (the "Additional" block)
-+# session	required			pam_lastlog.so showfailed #NOBLE_TODO: Commented out when pam_lastlog is availble again
++session	required			pam_faillock.so showfailed
  # end of pam-auth-update config


### PR DESCRIPTION
this will change the deprecated pam_lastlog which logged showfailed logins
to pam_faillock which also shows failed logins in a similar matter.
this will solve #343 

this pr also removed the rsyslog adiscon ppa. as we now use the rsyslog provided in the main ubuntu package repo.
this also contributes to better reproduciblty 
this wil solve #299 
