### PR TITLE
set pam_lastlog2 optional

### DIFF
--- a/bosh-stemcell/spec/os_image/ubuntu_noble_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_noble_spec.rb
@@ -292,7 +292,7 @@ EOF
 
   context 'display the number of unsuccessful logon/access attempts since the last successful logon/access (stig: V-51875)' do
     describe file('/etc/pam.d/common-password') do
-      its(:content) { should match /session\trequired\t\t\tpam_lastlog\.so showfailed/ }
+      its(:content) { should match /session\toptional\t\t\tpam_lastlog2\.so showfailed/ }
     end
   end
 

--- a/stemcell_builder/stages/password_policies/assets/ubuntu/common-password.patch
+++ b/stemcell_builder/stages/password_policies/assets/ubuntu/common-password.patch
@@ -13,5 +13,5 @@
  # since the modules above will each just jump around
  password	required			pam_permit.so
  # and here are more per-package modules (the "Additional" block)
-+# session	required			pam_lastlog.so showfailed #NOBLE_TODO: Commented out when pam_lastlog is availble again
++session	optional			pam_lastlog2.so showfailed #NOBLE_TODO: this will only work if util-linux =>2.40 which provide pam_lastlog2.so or if users will install it manually
  # end of pam-auth-update config


### PR DESCRIPTION
if util-linux 2.40 will be backported to noble. or the user provide the pam_lastlog2.so them self this setting wil then be used