### PR TITLE
remove common-password check in warden

### DIFF
--- a/bosh-stemcell/spec/stemcells/warden_spec.rb
+++ b/bosh-stemcell/spec/stemcells/warden_spec.rb
@@ -21,9 +21,4 @@ describe 'Warden Stemcell', stemcell_image: true do
     end
   end
 
-  context 'pam common-password config' do
-    describe file('/etc/pam.d/common-password') do
-      its(:content) { should include('#session	required			pam_faillock.so') }
-    end
-  end
 end


### PR DESCRIPTION
the common-password check was added in pr #397 
and this was added due to a mistake in #393  and fixed with  #398 