### PR TITLE
remove partitionar_type_mapping as we dont use it 

### DIFF
--- a/stemcell_builder/lib/prelude_agent.bash
+++ b/stemcell_builder/lib/prelude_agent.bash
@@ -1,4 +1,0 @@
-
-function get_partitioner_type_mapping {
-  echo '"PartitionerType": "parted",'
-}

--- a/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
@@ -3,29 +3,4 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "PartitionerType": "parted",
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "HTTP",
-          "URI": "http://100.100.100.200",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
-        }
-      ],
-      "UseServerName": false,
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+cp $assets_dir/agent.json $chroot/var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
@@ -2,13 +2,12 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
 cat > $chroot/var/vcap/bosh/agent.json <<JSON
 {
   "Platform": {
     "Linux": {
-      $(get_partitioner_type_mapping)
+      "PartitionerType": "parted",
       "CreatePartitionIfNoEphemeralDisk": true,
       "DevicePathResolutionType": "virtio"
     }

--- a/stemcell_builder/stages/bosh_alicloud_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_alicloud_agent_settings/assets/agent.json
@@ -1,0 +1,24 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "virtio"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "http://100.100.100.200",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
+        }
+      ],
+      "UseServerName": false,
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
@@ -2,13 +2,12 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
 cat > $chroot/var/vcap/bosh/agent.json <<JSON
 {
   "Platform": {
     "Linux": {
-      $(get_partitioner_type_mapping)
+      "PartitionerType": "parted",
       "DevicePathResolutionType": "virtio",
       "CreatePartitionIfNoEphemeralDisk": true,
       "ServiceManager": "systemd"

--- a/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
@@ -3,30 +3,4 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "PartitionerType": "parted",
-      "DevicePathResolutionType": "virtio",
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "ServiceManager": "systemd"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "HTTP",
-          "URI": "http://169.254.169.254",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key",
-          "TokenPath": "/latest/api/token"
-        }
-      ],
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+cp $assets_dir/agent.json $chroot/var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
@@ -1,0 +1,25 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "DevicePathResolutionType": "virtio",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "ServiceManager": "systemd"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "http://169.254.169.254",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key",
+          "TokenPath": "/latest/api/token"
+        }
+      ],
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_azure_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_agent_settings/apply.sh
@@ -3,29 +3,4 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-# Set SettingsPath but never use it because file_meta_service is avaliable only when the settings file exists.
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "scsi",
-      "PartitionerType": "parted",
-      "ServiceManager": "systemd"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "File",
-          "MetaDataPath": "",
-          "UserDataPath": "/var/lib/cloud/instance/user-data.txt",
-          "SettingsPath": "/var/lib/cloud/instance/user-data.txt"
-        }
-      ],
-      "UseServerName": true
-    }
-  }
-}
-JSON
+cp $assets_dir/agent.json $chroot/var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_azure_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_azure_agent_settings/assets/agent.json
@@ -1,0 +1,23 @@
+{
+  "Platform": {
+    "Linux": {
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "scsi",
+      "PartitionerType": "parted",
+      "ServiceManager": "systemd"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "File",
+          "MetaDataPath": "",
+          "UserDataPath": "/var/lib/cloud/instance/user-data.txt",
+          "SettingsPath": "/var/lib/cloud/instance/user-data.txt"
+        }
+      ],
+      "UseServerName": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
@@ -2,7 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
 agent_settings_file=$chroot/var/vcap/bosh/agent.json
 
@@ -10,7 +9,7 @@ cat > $agent_settings_file <<JSON
 {
   "Platform": {
     "Linux": {
-      $(get_partitioner_type_mapping)
+      "PartitionerType": "parted",
       "CreatePartitionIfNoEphemeralDisk": true,
       "DevicePathResolutionType": "virtio",
       "ServiceManager": "systemd"

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
@@ -3,32 +3,4 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-agent_settings_file=$chroot/var/vcap/bosh/agent.json
-
-cat > $agent_settings_file <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "PartitionerType": "parted",
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio",
-      "ServiceManager": "systemd"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "HTTP",
-          "URI": "http://169.254.169.254:39724",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys"
-        }
-      ],
-      "UseServerName": true,
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+cp $assets_dir/agent.json $chroot/var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/assets/agent.json
@@ -1,0 +1,25 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "virtio",
+      "ServiceManager": "systemd"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "http://169.254.169.254:39724",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys"
+        }
+      ],
+      "UseServerName": true,
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
@@ -2,14 +2,13 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
 cat > $chroot/var/vcap/bosh/agent.json <<JSON
 {
   "Platform": {
     "Linux": {
       "CreatePartitionIfNoEphemeralDisk": true,
-      $(get_partitioner_type_mapping)
+      "PartitionerType": "parted",
       "DevicePathResolutionType": "virtio",
       "VirtioDevicePrefix": "google",
       "ServiceManager": "systemd"

--- a/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
@@ -3,33 +3,4 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "PartitionerType": "parted",
-      "DevicePathResolutionType": "virtio",
-      "VirtioDevicePrefix": "google",
-      "ServiceManager": "systemd"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "InstanceMetadata",
-          "URI": "http://169.254.169.254",
-          "SettingsPath": "/computeMetadata/v1/instance/attributes/bosh_settings",
-          "Headers": {
-            "Metadata-Flavor": "Google"
-          }
-        }
-      ],
-
-      "UseServerName": true,
-      "UseRegistry": false
-    }
-  }
-}
-JSON
+cp $assets_dir/agent.json $chroot/var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_google_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_google_agent_settings/assets/agent.json
@@ -1,0 +1,28 @@
+{
+  "Platform": {
+    "Linux": {
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "PartitionerType": "parted",
+      "DevicePathResolutionType": "virtio",
+      "VirtioDevicePrefix": "google",
+      "ServiceManager": "systemd"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "InstanceMetadata",
+          "URI": "http://169.254.169.254",
+          "SettingsPath": "/computeMetadata/v1/instance/attributes/bosh_settings",
+          "Headers": {
+            "Metadata-Flavor": "Google"
+          }
+        }
+      ],
+
+      "UseServerName": true,
+      "UseRegistry": false
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
@@ -2,7 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
 agent_settings_file=$chroot/var/vcap/bosh/agent.json
 
@@ -10,7 +9,7 @@ cat > $agent_settings_file <<JSON
 {
   "Platform": {
     "Linux": {
-      $(get_partitioner_type_mapping)
+      "PartitionerType": "parted",
       "CreatePartitionIfNoEphemeralDisk": true,
       "DevicePathResolutionType": "virtio",
       "ServiceManager": "systemd"

--- a/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
@@ -3,46 +3,4 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-agent_settings_file=$chroot/var/vcap/bosh/agent.json
-
-cat > $agent_settings_file <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "PartitionerType": "parted",
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio",
-      "ServiceManager": "systemd"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "File",
-          "SettingsPath": "/var/vcap/bosh/agent-bootstrap-env.json"
-        },
-        {
-          "Type": "ConfigDrive",
-          "DiskPaths": [
-            "/dev/disk/by-label/CONFIG-2",
-            "/dev/disk/by-label/config-2"
-          ],
-          "MetaDataPath": "ec2/latest/meta-data.json",
-          "UserDataPath": "ec2/latest/user-data"
-        },
-        {
-          "Type": "HTTP",
-          "URI": "http://169.254.169.254",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
-        }
-      ],
-
-      "UseServerName": true,
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+cp $assets_dir/agent.json $chroot/var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_openstack_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/assets/agent.json
@@ -1,0 +1,39 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "virtio",
+      "ServiceManager": "systemd"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "File",
+          "SettingsPath": "/var/vcap/bosh/agent-bootstrap-env.json"
+        },
+        {
+          "Type": "ConfigDrive",
+          "DiskPaths": [
+            "/dev/disk/by-label/CONFIG-2",
+            "/dev/disk/by-label/config-2"
+          ],
+          "MetaDataPath": "ec2/latest/meta-data.json",
+          "UserDataPath": "ec2/latest/user-data"
+        },
+        {
+          "Type": "HTTP",
+          "URI": "http://169.254.169.254",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
+        }
+      ],
+
+      "UseServerName": true,
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
@@ -3,24 +3,4 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "PartitionerType": "parted",
-      "DevicePathResolutionType": "scsi",
-      "ServiceManager": "systemd"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "CDROM",
-          "FileName": "env"
-        }
-      ]
-    }
-  }
-}
-JSON
+cp $assets_dir/agent.json $chroot/var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
@@ -2,13 +2,12 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
 cat > $chroot/var/vcap/bosh/agent.json <<JSON
 {
   "Platform": {
     "Linux": {
-      $(get_partitioner_type_mapping)
+      "PartitionerType": "parted",
       "DevicePathResolutionType": "scsi",
       "ServiceManager": "systemd"
     }

--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/assets/agent.json
@@ -1,0 +1,19 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "DevicePathResolutionType": "scsi",
+      "ServiceManager": "systemd"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "CDROM",
+          "FileName": "env"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
for the past 5 year we have not used this function that coul switch between partitionar type.
and as parted is now the only partitioner program we used. so by removing this we make the code a little bit less complex
