### PR TITLE
gce-compute-image-packages has added a jq package dependency

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-google-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-jammy-google-additions.txt
@@ -2,3 +2,6 @@ gce-compute-image-packages
 google-compute-engine
 google-compute-engine-oslogin
 google-guest-agent
+jq
+libjq1:amd64
+libonig5:amd64


### PR DESCRIPTION
https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/stemcells-ubuntu-jammy/jobs/build-google-kvm/builds/208