### PR TITLE
Update 60-bosh-sysctl.conf

### DIFF
--- a/stemcell_builder/stages/bosh_sysctl/assets/60-bosh-sysctl.conf
+++ b/stemcell_builder/stages/bosh_sysctl/assets/60-bosh-sysctl.conf
@@ -22,8 +22,8 @@ net.ipv4.icmp_ignore_bogus_error_responses=1
 
 net.ipv6.conf.all.disable_ipv6=0
 net.ipv6.conf.default.disable_ipv6=0
-net.ipv6.conf.default.accept_redirects=1
-net.ipv6.conf.all.accept_redirects=1
+net.ipv6.conf.default.accept_redirects=0
+net.ipv6.conf.all.accept_redirects=0
 net.ipv6.route.flush=0
 
 kernel.exec-shield=1


### PR DESCRIPTION
Our lynis scans reported this as a potential vulnerability. We tested that the ipv6 connection still works after this is disabled.