### PR TITLE
Use long-form command flags in scripts

### DIFF
--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -24,7 +24,7 @@ git config --global --add safe.directory /opt/bosh
 
 function pkg_mgr {
   run_in_chroot $chroot "apt-get update"
-  run_in_chroot $chroot "export DEBIAN_FRONTEND=noninteractive;apt-get -f -y --no-install-recommends $*"
+  run_in_chroot $chroot "export DEBIAN_FRONTEND=noninteractive; apt-get install --fix-broken --no-install-recommends --assume-yes $*"
   run_in_chroot $chroot "apt-get clean"
 }
 


### PR DESCRIPTION
Terse flags only lead to obfuscation, this commit changs the short flags passed to `apt-get` to their corresponding long-form versions. The commit also adds the implicit `install` command to `apt-get`.