### PR TITLE
Disable cloud logging to avoid a bug in the current version of the google-guest-agent package

### DIFF
--- a/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
+++ b/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
@@ -8,3 +8,5 @@ optimize_local_ssd = true
 set_host_keys = false
 shutdown = false
 startup = false
+[Core]
+cloud_logging_enabled = false


### PR DESCRIPTION
Context: https://github.com/cloudfoundry/bosh-google-cpi-release/issues/359