### PR TITLE
Removes 'install' argument in pkg_mgr function

### DIFF
--- a/stemcell_builder/lib/prelude_apply.bash
+++ b/stemcell_builder/lib/prelude_apply.bash
@@ -24,7 +24,7 @@ git config --global --add safe.directory /opt/bosh
 
 function pkg_mgr {
   run_in_chroot $chroot "apt-get update"
-  run_in_chroot $chroot "export DEBIAN_FRONTEND=noninteractive; apt-get install --fix-broken --no-install-recommends --assume-yes $*"
+  run_in_chroot $chroot "export DEBIAN_FRONTEND=noninteractive; apt-get --fix-broken --no-install-recommends --assume-yes $*"
   run_in_chroot $chroot "apt-get clean"
 }
 


### PR DESCRIPTION
This commit restores the `pkg_mgr` function to its previous general-purpose state. This resolves this issue in CI:

```
+ local 'script=export DEBIAN_FRONTEND=noninteractive; apt-get install --fix-broken --no-install-recommends --assume-yes install systemd'
...
Reading package lists...
Building dependency tree...
E: Unable to locate package install
```

The `pkg_mgr` function is used for install, purge, and dist-upgrade, so hard-coding the 'install' operation isn't right.