### PR TITLE
Revert "Disable cloud logging to avoid a bug in the current version of the google-guest-agent package"

### DIFF
--- a/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
+++ b/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
@@ -8,5 +8,3 @@ optimize_local_ssd = true
 set_host_keys = false
 shutdown = false
 startup = false
-[Core]
-cloud_logging_enabled = false


### PR DESCRIPTION
Reverts cloudfoundry/bosh-linux-stemcell-builder#413

This did not avoid the problem. Apparently the `cloud_logging_enabled` flag doesn't exist on our version of the package so we might as well remove this to avoid future confusion about why we are configuring it.