### PR TITLE
Update systemd-resolved to also listen on 169.254.0.53

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -248,6 +248,7 @@ module Bosh::Stemcell
         :base_apt,
         :base_ubuntu_build_essential,
         :base_ubuntu_packages,
+        :bosh_systemd_resolved,
         :base_file_permission,
         :base_ssh,
         :bosh_sysstat,

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -27,6 +27,7 @@ module Bosh::Stemcell
             :base_apt,
             :base_ubuntu_build_essential,
             :base_ubuntu_packages,
+            :bosh_systemd_resolved,
             :base_file_permission,
             :base_ssh,
             :bosh_sysstat,

--- a/bosh-stemcell/spec/os_image/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_spec.rb
@@ -538,4 +538,14 @@ bosh_sudoers:!::
 HERE
     end
   end
+
+  describe 'systemd-resolved modifications' do
+    describe file('/lib/systemd/system/create-systemd-resolved-listener-address.service') do
+      its(:content) { should match /ip addr add 169\.254\.0\.53 dev lo/ }
+    end
+
+    describe file('/etc/systemd/resolved.conf.d/add-container-listener-address.conf') do
+      its(:content) { should match /DNSStubListenerExtra=169\.254\.0\.53/ }
+    end
+  end
 end

--- a/stemcell_builder/stages/bosh_systemd_resolved/apply.sh
+++ b/stemcell_builder/stages/bosh_systemd_resolved/apply.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/lib/prelude_bosh.bash
+
+mkdir -p "${chroot}/etc/systemd/resolved.conf.d/"
+cp "$(dirname "$0")/assets/add-container-listener-address.conf" "${chroot}/etc/systemd/resolved.conf.d/"
+
+cp "$(dirname "$0")/assets/create-systemd-resolved-listener-address.service" "${chroot}/lib/systemd/system/"
+run_in_chroot "${chroot}" "systemctl enable create-systemd-resolved-listener-address.service"

--- a/stemcell_builder/stages/bosh_systemd_resolved/assets/add-container-listener-address.conf
+++ b/stemcell_builder/stages/bosh_systemd_resolved/assets/add-container-listener-address.conf
@@ -1,0 +1,2 @@
+[Resolve]
+DNSStubListenerExtra=169.254.0.53

--- a/stemcell_builder/stages/bosh_systemd_resolved/assets/create-systemd-resolved-listener-address.service
+++ b/stemcell_builder/stages/bosh_systemd_resolved/assets/create-systemd-resolved-listener-address.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Add 169.254.0.53 address so systemd-resolvconf can be accessed by container namespaces
+
+DefaultDependencies=no
+After=systemd-sysctl.service systemd-sysusers.service
+Before=systemd-resolved.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'if ! ip addr show dev lo | grep -q 169.254.0.53; then ip addr add 169.254.0.53 dev lo; fi'
+
+[Install]
+RequiredBy=systemd-resolved.service


### PR DESCRIPTION
Network namespaces (containers) do not allow routing of 127 traffic. So app containers are unable to communicate with the current 127.0.0.53 address where systemd-resolved is listening on the host.