### PR TITLE
Decreases "recordfail" timeout to five seconds

### DIFF
--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -90,6 +90,7 @@ CGROUP_FIX="systemd.unified_cgroup_hierarchy=false"
 
 cat >${image_mount_point}/etc/default/grub <<EOF
 GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 apparmor=1 security=apparmor ${grub_suffix} ${CGROUP_FIX}"
+GRUB_RECORDFAIL_TIMEOUT=5
 EOF
 
 # we use a random password to prevent user from editing the boot menu

--- a/stemcell_builder/stages/image_install_grub_efi/apply.sh
+++ b/stemcell_builder/stages/image_install_grub_efi/apply.sh
@@ -95,6 +95,7 @@ CGROUP_FIX="systemd.unified_cgroup_hierarchy=false"
 
 cat >${image_mount_point}/etc/default/grub <<EOF
 GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 biosdevname=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 ipv6.disable=1 audit=1 cgroup_enable=memory swapaccount=1 apparmor=1 security=apparmor ${grub_suffix} ${CGROUP_FIX}"
+GRUB_RECORDFAIL_TIMEOUT=5
 EOF
 
 # we use a random password to prevent user from editing the boot menu


### PR DESCRIPTION
This commit reduces the boot timeout for the "recordfail" GRUB boot logic from its default (30 seconds) to five seconds. The ordinary boot wait time is five seconds, so this makes the boot wait the same regardless of which branch is taken.

Currently, we strongly believe that the first boot of any VM based on a stemcell falls into the "recordfail" branch, and has its startup delayed by 30 seconds for no good reason.

Do note that this environment variable is not documented in the official GRUB documentation, but -then again- most of the environment variables used by the GRUB configuration generation machinery are also undocumented... source code inspection is the only way to learn of their existence.