### PR TITLE
Removes scsitools from the ubuntu noble.

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -436,7 +436,6 @@ rsyslog-gnutls
 rsyslog-openssl
 rsyslog-relp
 runit
-scsitools
 sed
 sensible-utils
 sg3-utils

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -13,7 +13,6 @@ flex psmisc apparmor-utils iptables nftables sysstat \
 rsync openssh-server traceroute libncurses5-dev quota \
 libaio1t64 gdb libcap2-bin libcap2-dev libbz2-dev \
 cmake uuid-dev libgcrypt-dev ca-certificates \
-scsitools mg htop module-assistant debhelper runit parted \
 cloud-guest-utils anacron software-properties-common \
 xfsprogs gdisk chrony dbus nvme-cli rng-tools fdisk \
 ethtool libpam-pwquality gpg-agent libcurl4 libcurl4-openssl-dev resolvconf net-tools ifupdown"


### PR DESCRIPTION
This commit removes scsitools from the ubuntu noble.

This is a part of cleaning up packages which are not really important during the lifecycle of a VM. As this is not used anymore in agent or in the stemcell builder.

Follow up on [415](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/415)