### PR TITLE
Restore apt sources before image create

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -105,6 +105,7 @@ module Bosh::Stemcell
         bosh_harden
         bosh_openstack_agent_settings
         bosh_clean_ssh
+        restore_apt_sources
         image_create
         image_install_grub
         sbom_create
@@ -123,6 +124,7 @@ module Bosh::Stemcell
         bosh_harden
         bosh_cloudstack_agent_settings
         bosh_clean_ssh
+        restore_apt_sources
         image_create
         image_install_grub
         sbom_create
@@ -141,6 +143,7 @@ module Bosh::Stemcell
         :bosh_enable_password_authentication,
         :bosh_vsphere_agent_settings,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -160,6 +163,7 @@ module Bosh::Stemcell
         :bosh_aws_agent_settings,
         :bosh_clean_ssh,
         :udev_aws_rules,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -178,6 +182,7 @@ module Bosh::Stemcell
         bosh_harden
         bosh_alicloud_agent_settings
         bosh_clean_ssh
+        restore_apt_sources
         image_create
         image_install_grub
         sbom_create
@@ -194,6 +199,7 @@ module Bosh::Stemcell
         :bosh_harden,
         :bosh_google_agent_settings,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -210,6 +216,7 @@ module Bosh::Stemcell
         :bosh_clean,
         :bosh_harden,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -230,6 +237,7 @@ module Bosh::Stemcell
         :bosh_harden,
         :bosh_azure_agent_settings,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -252,6 +260,7 @@ module Bosh::Stemcell
         :bosh_softlayer_agent_settings,
         :bosh_config_root_ssh_login,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -263,7 +272,6 @@ module Bosh::Stemcell
     def finish_stemcell_stages
       [
         :bosh_package_list,
-        :restore_apt_sources,
       ]
     end
 

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -92,11 +92,11 @@ module Bosh::Stemcell
             :bosh_aws_agent_settings,
             :bosh_clean_ssh,
             :udev_aws_rules,
+            :restore_apt_sources,
             :image_create,
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
-            :restore_apt_sources,
           ]
         }
         let(:aws_package_stemcell_stages) {
@@ -124,11 +124,11 @@ module Bosh::Stemcell
             :bosh_harden,
             :bosh_alicloud_agent_settings,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create,
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
-            :restore_apt_sources,
           ]
         }
 
@@ -158,11 +158,11 @@ module Bosh::Stemcell
             :bosh_harden,
             :bosh_google_agent_settings,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create,
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
-            :restore_apt_sources,
           ]
         }
 
@@ -195,11 +195,11 @@ module Bosh::Stemcell
               :bosh_harden,
               :bosh_openstack_agent_settings,
               :bosh_clean_ssh,
+              :restore_apt_sources,
               :image_create,
               :image_install_grub,
               :sbom_create,
               :bosh_package_list,
-              :restore_apt_sources,
             ]
           )
           expect(stage_collection.package_stemcell_stages('qcow2')).to eq(
@@ -227,11 +227,11 @@ module Bosh::Stemcell
               :bosh_harden,
               :bosh_cloudstack_agent_settings,
               :bosh_clean_ssh,
+              :restore_apt_sources,
               :image_create,
               :image_install_grub,
               :sbom_create,
               :bosh_package_list,
-              :restore_apt_sources,
             ]
           )
           expect(stage_collection.package_stemcell_stages('qcow2')).to eq(
@@ -258,11 +258,11 @@ module Bosh::Stemcell
               :bosh_enable_password_authentication,
               :bosh_vsphere_agent_settings,
               :bosh_clean_ssh,
+              :restore_apt_sources,
               :image_create_efi,
               :image_install_grub_efi,
               :sbom_create,
               :bosh_package_list,
-              :restore_apt_sources,
             ]
           )
           expect(stage_collection.package_stemcell_stages('ovf')).to eq(vmware_package_stemcell_steps)
@@ -287,11 +287,11 @@ module Bosh::Stemcell
                 :bosh_enable_password_authentication,
                 :bosh_vsphere_agent_settings,
                 :bosh_clean_ssh,
+                :restore_apt_sources,
                 :image_create_efi,
                 :image_install_grub_efi,
                 :sbom_create,
                 :bosh_package_list,
-                :restore_apt_sources,
             ]
             )
             expect(stage_collection.package_stemcell_stages('ovf')).to eq(vmware_package_stemcell_steps)
@@ -313,11 +313,11 @@ module Bosh::Stemcell
             :bosh_harden,
             :bosh_azure_agent_settings,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create,
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
-            :restore_apt_sources,
           ]
         }
 
@@ -354,10 +354,10 @@ module Bosh::Stemcell
                 :bosh_softlayer_agent_settings,
                 :bosh_config_root_ssh_login,
                 :bosh_clean_ssh,
+                :restore_apt_sources,
                 :image_create_softlayer_two_partitions,
                 :image_install_grub_softlayer_two_partitions,
                 :bosh_package_list,
-                :restore_apt_sources,
               ]
             )
             expect(stage_collection.package_stemcell_stages('ovf')).to eq(vmware_package_stemcell_steps)
@@ -374,11 +374,11 @@ module Bosh::Stemcell
             :bosh_clean,
             :bosh_harden,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create,
             :image_install_grub,
             :sbom_create,
             :bosh_package_list,
-            :restore_apt_sources,
           ]
         }
         let(:package_stemcell_stages) {


### PR DESCRIPTION
Previously, we were attempting to restore the original apt sources (instead of shipping w/ snapshot sources) after image create. This step needs to come before image create.