### PR TITLE
Fix monit-api-access cgroup location in warden-cpi

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -14,7 +14,8 @@ monit_isolation_classid=2958295041
 
 permit_monit_access() {
     net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk '{ print $2 }' )"
-    monit_access_cgroup="${net_cls_location}/monit-api-access"
+    net_cls_subproc="$(grep net_cls /proc/self/cgroup | awk -F ":" '{ print $3 }' )"
+    monit_access_cgroup="${net_cls_location}/${net_cls_subproc}/monit-api-access"
 
     mkdir -p "${monit_access_cgroup}"
     echo "${monit_isolation_classid}" > "${monit_access_cgroup}/net_cls.classid"


### PR DESCRIPTION
- In the containers we start up with the warden-cpi, cgroups are mounted directly from the parent VM, but the container root process refers to a container subdirectory in `/proc/self/cgroup`. Our helper script for setting up monit-api-access wasn't looking at that subpath when establishing the monit-api-access directory, resulting in all the subprocesses putting tasks into the cgroup of the parent VM, which meant that processes with the same name on different warden-cpi VMs would use the same file paths under cgroups.
- We used to get away with this but recently runc started paying attention to errors from container shutdown, so the errors we were getting all along from trying to remove processes that were still running in other containers started to cause [failures](https://github.com/cloudfoundry/bpm-release/issues/176).
- This change checks /proc/self/cgroup for a subpath and uses it if there is one, so each container has its own location to manage processes.