### PR TITLE
STIG: this PR allows stepping system clock on any clock update

### DIFF
--- a/bosh-stemcell/spec/stemcells/stig_spec.rb
+++ b/bosh-stemcell/spec/stemcells/stig_spec.rb
@@ -137,6 +137,7 @@ describe 'Stig test case verification', stemcell_image: true, security_spec: tru
       V-75779
       V-75865
       V-75851
+      V-260520
     ]
 
     expected_stig_test_cases = expected_base_stig_test_cases

--- a/bosh-stemcell/spec/support/os_image_chrony_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_chrony_shared_examples.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'an os with chrony' do
-  describe '(stig: V-38620 V-38621)' do
+  describe '(stig: V-38620 V-38621 V-260520)' do
     describe file('/var/vcap/bosh/bin/sync-time') do
       it { should be_file }
       its(:content) { should match(/chronyc reload sources/) }
@@ -8,7 +8,7 @@ shared_examples_for 'an os with chrony' do
 
     describe file('/etc/chrony/chrony.conf') do
       it { should be_file }
-      its(:content) { should match(/makestep 1 3/) }
+      its(:content) { should match(/makestep 1 -1/) }
     end
   end
 end

--- a/stemcell_builder/stages/bosh_ntp/apply.sh
+++ b/stemcell_builder/stages/bosh_ntp/apply.sh
@@ -7,6 +7,7 @@ source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
 sed -i "/^pool /d" $chroot/etc/chrony/chrony.conf
+sed -i "s/^makestep .*/makestep 1 -1/" $chroot/etc/chrony/chrony.conf
 cp $dir/assets/chrony-updater $chroot/$bosh_dir/bin/sync-time
 
 chmod 0755 $chroot/$bosh_dir/bin/sync-time


### PR DESCRIPTION
This PR allows stepping system clock on any clock update. 
This is to avoid `chrony` taking a long time to correct drift, if the clock is too far from the true time.

## STIG reference

### Group ID (Vulid):
V-260520
### Group Title:
SRG-OS-000356-GPOS-00144
### Rule ID:
SV-260520r1044776_rule
### Severity:
CAT III
### Rule Version (STIG-ID):
UBTU-22-252015
### Rule Title: 
Ubuntu 22.04 LTS must synchronize internal information system clocks to the authoritative time source when the time difference is greater than one second.

### Vulnerability Discussion:
 Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events.  
  
Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network. Organizations should consider setting time periods for different types of systems (e.g., financial, legal, or mission-critical systems).  
  
Organizations should also consider endpoints that may not have regular access to the authoritative time server (e.g., mobile, teleworking, and tactical endpoints). This requirement is related to the comparison done every 24 hours in SRG-OS-000355 because a comparison must be done to determine the time difference.

### Check Content:
Verify Ubuntu 22.04 LTS synchronizes internal system clocks to the authoritative time source when the time difference is greater than one second.  
 
**Note**: If the system is not networked, this requirement is not applicable. 
 
Check the value of "makestep" by using the following command:  
  
     $ grep -ir makestep /etc/chrony* 
     makestep 1 -1 
 
If `makestep` is not set to `1 -1`, is commented out, or is missing, this is a finding. 
 
Verify the NTP service is active and the system clock is synchronized with the authoritative time source: 
 
     $ timedatectl | grep -Ei '(synchronized|service)' 
     System clock synchronized: yes 
     NTP service: active 
 
If the NTP service is not active, this is a finding.

If the system clock is not synchronized, this is a finding.

### Fix Text:
Configure chrony to synchronize the internal system clocks to the authoritative source when the time difference is greater than one second by doing the following:  
  
Edit the `/etc/chrony/chrony.conf` file and add:  
 
     makestep 1 -1 
 
Restart the chrony service:  
  
     $ sudo systemctl restart chrony.service

## Chrony FAQ
*Normally, it is recommended to allow the step only in the first few updates, but in some cases (e.g. a computer without an RTC or virtual machine which can be suspended and resumed with an incorrect time) it might be necessary to allow the step on any clock update.*

[3.4. Is chronyd allowed to step the system clock?](https://chrony-project.org/faq.html#_is_chronyd_allowed_to_step_the_system_clock)

## Other reference(s)

[Kubernetes image-builder](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/providers/tasks/azure.yml#L26-L32)