### PR TITLE
STIG: configure apt to remove previous versions of software components and dependencies after being updated

### DIFF
--- a/bosh-stemcell/spec/stemcells/stig_spec.rb
+++ b/bosh-stemcell/spec/stemcells/stig_spec.rb
@@ -136,7 +136,7 @@ describe 'Stig test case verification', stemcell_image: true, security_spec: tru
       V-80969
       V-75779
       V-75865
-      V-75851
+      V-260477
     ]
 
     expected_stig_test_cases = expected_base_stig_test_cases

--- a/bosh-stemcell/spec/stemcells/stig_spec.rb
+++ b/bosh-stemcell/spec/stemcells/stig_spec.rb
@@ -136,6 +136,7 @@ describe 'Stig test case verification', stemcell_image: true, security_spec: tru
       V-80969
       V-75779
       V-75865
+      V-75851
       V-260477
     ]
 

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -799,4 +799,14 @@ shared_examples_for 'every OS image' do
       its (:content) { should match /^cron\.\*\s+\/var\/log\/cron\.log$/ }
     end
   end
+
+  describe 'apt removes all software components after updated versions have been installed (stig: V-260477)' do
+    describe file('/etc/apt/apt.conf.d/50unattended-upgrades') do
+      expected = <<-EXPECTED
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+EXPECTED
+      its(:content) { should eq expected.chomp }
+    end
+  end
 end

--- a/stemcell_builder/stages/base_apt/apply.sh
+++ b/stemcell_builder/stages/base_apt/apply.sh
@@ -23,6 +23,8 @@ else
 EOS
 fi
 
+cp $assets_dir/etc/apt/apt.conf.d/50unattended-upgrades  $chroot/etc/apt/apt.conf.d/50unattended-upgrades
+
 # Upgrade systemd/upstart first, to prevent it from messing up our stubs and starting daemons anyway
 pkg_mgr install systemd
 

--- a/stemcell_builder/stages/base_apt/assets/etc/apt/apt.conf.d/50unattended-upgrades
+++ b/stemcell_builder/stages/base_apt/assets/etc/apt/apt.conf.d/50unattended-upgrades
@@ -1,0 +1,2 @@
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";


### PR DESCRIPTION
## STIG reference

### Group ID (Vulid):
V-260477
### Group Title:
SRG-OS-000437-GPOS-00194
### Rule ID:
SV-260477r1044773_rule
### Severity:
CAT II
### Rule Version (STIG-ID):
UBTU-22-214015
### Rule Title: 
Ubuntu 22.04 LTS must be configured so that the Advance Package Tool (APT) removes all software components after updated versions have been installed.

### Vulnerability Discussion:
Previous versions of software components that are not removed from the information system after updates have been installed may be exploited by adversaries. Some information technology products may remove older versions of software automatically from the information system.  

### Check Content:
Verify APT is configured to remove all software components after updated versions have been installed by using the following command:  
  
     $ grep -i remove-unused /etc/apt/apt.conf.d/50unattended-upgrades 
     Unattended-Upgrade::Remove-Unused-Kernel-Packages "true"; 
     Unattended-Upgrade::Remove-Unused-Dependencies "true"; 
  
If `Unattended-Upgrade::Remove-Unused-Kernel-Packages` and `Unattended-Upgrade::Remove-Unused-Dependencies` are not set to `true`, are commented out, or are missing, this is a finding.

### Fix Text:
Configure APT to remove all software components after updated versions have been installed.  
  
Add or modify the following lines in the `/etc/apt/apt.conf.d/50unattended-upgrades` file:  
 ```
Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
Unattended-Upgrade::Remove-Unused-Dependencies "true"; 
```
