### PR TITLE
Install yq from github on jammy

### DIFF
--- a/ci/docker/os-image-stemcell-builder/Dockerfile
+++ b/ci/docker/os-image-stemcell-builder/Dockerfile
@@ -51,8 +51,11 @@ RUN \
     tar \
     wget \
     xvfb \
-    yq \
   && apt-get clean
+
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+      -O /usr/local/bin/yq \
+    && chmod +x /usr/local/bin/yq
 
 RUN groupadd -o -g ${GROUP_ID} ubuntu                  \
   && useradd -u ${USER_ID} -g ${GROUP_ID} -m ubuntu \


### PR DESCRIPTION
Resolves `Unable to locate package yq` error

This should resolve the error caused by https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/428