### PR TITLE
fix: run logrotate once every 5 minutes

### DIFF
--- a/stemcell_builder/stages/logrotate_config/assets/logrotate.timer
+++ b/stemcell_builder/stages/logrotate_config/assets/logrotate.timer
@@ -1,15 +1,10 @@
 [Unit]
-Description=random 1 min rotation of log files
+Description=Every 5 minutes rotation of logfiles using logrotate.
 Documentation=man:logrotate(8) man:logrotate.conf(5)
 
 [Timer]
-OnBootSec=1min
-#This was once 'OnUnitActiveSec', but now is not. A Customer problem lead us to discover that it is said that
-#'oneshot' Units are never actually Active, so they will sometimes never be scheduled.
-#See: <https://github.com/systemd/systemd/issues/6680#issuecomment-326228938>
-OnCalendar=*-*-* *:00/15:00
-RandomizedDelaySec=2min
-Persistent=true
+OnCalendar=*-*-* *:*:00/5
+RandomizedDelaySec=1min
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Same change as #425 but now for noble (minus a typo)

When a system is processing lots of data producing a high volume of logs running logrotate only once every 15 mintues can cause the disk to fill up if it is not big enough. This commit changes the logrotate timer to fire once per minute. If no logs need to be rotated logrotate will exit without modifying anything, this can be controlled via custom logrotate configuration.

This commit also removes the OnBootSec property as the timer fires every 5 minutes anyway, RandomizedDelaySec is reduced to one minute.

Resolves: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/424