### PR TITLE
Bump jammy vsphere default hardware version to 17

### DIFF
--- a/stemcell_builder/stages/image_ovf_vmx/apply.sh
+++ b/stemcell_builder/stages/image_ovf_vmx/apply.sh
@@ -45,7 +45,7 @@ vm_guestos=ubuntu-64
 
 cat > $ovf/$vm_hostname.vmx <<EOS
 config.version = "8"
-virtualHW.version = "13"
+virtualHW.version = "17"
 floppy0.present = "FALSE"
 nvram = "nvram"
 deploymentPlatform = "windows"


### PR DESCRIPTION
This drops support for the EOTS vcenter `6.5` and `6.7` bumping the minimum requirements to vsphere `7.0`. This is useful as it allows more disks for the pvSCSI controllers; going from 15 -> 63 disks per controller by default.

Just working on getting guidance on current usage of out of support vcenter versions before merging.

See also: #436 