### PR TITLE
Fix cloud-init logging format

### DIFF
--- a/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/05-logging.cfg
+++ b/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/05-logging.cfg
@@ -1,7 +1,7 @@
-=## This yaml formated config file handles setting
+## This yaml formatted config file handles setting
 ## logger information.  The values that are necessary to be set
 ## are seen at the bottom.  The top '_log' are only used to remove
-## redundency in a syslog and fallback-to-file case.
+## redundancy in a syslog and fallback-to-file case.
 ##
 ## The 'log_cfgs' entry defines a list of logger configs
 ## Each entry in the list is tried, and the first one that
@@ -69,4 +69,3 @@ log_cfgs:
 # 'tee -a /var/log/cloud-init-output.log' so the user can see output
 # there without needing to look on the console.
 output: {all: '| tee -a /var/log/cloud-init-output.log'}
-


### PR DESCRIPTION
The typo leads to problems when cloud-init attempts to load the logging configuration. This is evident in the daemon logs, as shown by the following stack trace:

> cloud-init[515]: 2025-09-24 12:07:29,260 - util.py[WARNING]: Failed
>   loading yaml blob. Invalid format at line 10 column 1: "expected
?   '<document start>', but found '<block mapping start>'
> cloud-init[515]:   in "<unicode string>", line 10, column 1:
> cloud-init[515]:     _log:
> cloud-init[515]:     ^"

>[!NOTE]
> For comparison, the upstream config has the correct [format](https://github.com/canonical/cloud-init/blob/main/config/cloud.cfg.d/05_logging.cfg).