### PR TITLE
Improve Azure chrony accuracy: change Hyper-V PTP poll 3 -> -1, add RT scheduling + OOM hardening

### DIFF
--- a/stemcell_builder/stages/bosh_azure_chrony/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_chrony/apply.sh
@@ -6,8 +6,24 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
+mkdir -p /etc/systemd/system/chrony.service.d
+
+cat > $chroot/etc/systemd/system/chrony.service.d/chrony-systemd-override.conf <<EOF
+# created by $0
+[Service]
+# Set the CPU scheduling policy to FIFO (First-In, First-Out), a real-time policy.
+CPUSchedulingPolicy=fifo
+
+# Set the real-time priority to the highest possible value (99).
+# This ensures chronyd runs before any other non-kernel, non-real-time tasks.
+CPUSchedulingPriority=50
+
+# Make the process less likely to be killed by the OOM killer
+OOMScoreAdjust=-500
+EOF
+
 cat > $chroot/etc/chrony/conf.d/azure_ptp.conf <<EOF
 # created by $0
 # https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
-refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0 stratum 2
+refclock PHC /dev/ptp_hyperv poll -1 dpoll -2 offset 0 stratum 2
 EOF


### PR DESCRIPTION
Switch chrony PHC refclock polling for /dev/ptp_hyperv from poll 3 to poll -1 (with existing dpoll -2) to tighten synchronization on Azure VMs. Added a systemd drop-in granting FIFO scheduling (priority 50) and OOMScoreAdjust -500 so chronyd remains stable under memory pressure.

**Background:** 
poll 3 corresponds to a 2^3 = 8s base interval; with dpoll -2 the dynamic range was 2–8s. This slower sampling delayed convergence after VM start, suspend/resume, or host migration and increased offset/jitter under bursty load. Setting poll -1 (2^-1 = 0.5s) shifts dynamic range (with dpoll -2) to 0.125–0.5s, yielding faster lock and lower RMS offset for time-sensitive workloads (e.g. distributed tracing, log ordering, certificate validation windows).

**Changes:**
Refclock line: poll 3 -> poll -1 (kept dpoll -2, offset 0, stratum 2)
Added systemd chrony.service override: FIFO scheduling, priority 50, OOMScoreAdjust -500.

**Benefits:**
Quicker convergence after boot or host events.
Reduced steady-state offset and jitter on Azure Hyper-V PTP.
Increased resilience against OOM kills and CPU contention.

**Testing Performed:**

- Long-running observation: stable lower RMS offset and reduced jitter versus previous config
- chronyc tracking showed improved convergence after restart events or live migrations
- Multi-day fio mixed read/write stress (sustained high IO + CPU bursts) showed no degradation in chrony accuracy, no adverse impact on workload performance, and no elevated chronyd CPU usage

- Verified chronyc tracking: reduced offset (avg improvement ~4 ms -> ~50 µs) and lower jitter.
<img width="1846" height="558" alt="image" src="https://github.com/user-attachments/assets/3447790d-d539-4a30-8ee7-eee647b802d8" />

- VS. default chrony configuration
<img width="1849" height="559" alt="image" src="https://github.com/user-attachments/assets/4bcfea9f-a694-4daf-b34d-7bbbee977f23" />

- Monitored CPU: negligible (<0.1% increase) on tested Standard D2as v5 (2 vcpus, 8 GiB memory).
<img width="1852" height="670" alt="image" src="https://github.com/user-attachments/assets/78bad3b8-b40a-40e7-812a-b27bf5483ec0" />

- VS. default chrony configuration
<img width="1844" height="666" alt="image" src="https://github.com/user-attachments/assets/1dfdd98e-01ed-4222-bc00-56e206987860" />

Confirmed systemd status and real-time scheduling applied :

```bash
systemctl show chrony | egrep '(CPUSchedulingPriority|CPUSchedulingPolicy|OOMScoreAdjust)'
OOMScoreAdjust=-500
CPUSchedulingPolicy=1
CPUSchedulingPriority=50
```

**Rollback:** 
Change **poll -1 back to 3 and remove the systemd drop-in** directory if higher sampling cost becomes problematic.

**Future Considerations:** 
Could make poll/dpoll configurable via environment variables during stemcell build; optionally add telemetry gating based on instance size.