### PR TITLE
Ignore SR-IOV VF interfaces for Azure stemcells

### DIFF
--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -42,4 +42,41 @@ describe 'Azure Stemcell', stemcell_image: true do
       its(:content) { should include('"PartitionerType": "parted"') }
     end
   end
+
+  context 'installed by system_azure_network', {
+    exclude_on_alicloud: true,
+    exclude_on_aws: true,
+    exclude_on_google: true,
+    exclude_on_vcloud: true,
+    exclude_on_vsphere: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+    exclude_on_softlayer: true,
+  } do
+    describe 'SR-IOV VF udev rules' do
+      subject { file('/etc/udev/rules.d/10-azure-sriov-unmanaged.rules') }
+
+      it { should be_mode(644) }
+      it { should be_owned_by('root') }
+
+      its(:content) { should match /SUBSYSTEM=="net"/ }
+      its(:content) { should match /ATTR\{flags\}=="0\?\?\[89ABCDEF\]\*"/ }
+      its(:content) { should match /ENV\{AZURE_UNMANAGED_SRIOV\}="1"/ }
+      its(:content) { should match /ENV\{ID_NET_MANAGED_BY\}="unmanaged"/ }
+      its(:content) { should match /ENV\{NM_UNMANAGED\}="1"/ }
+      its(:content) { should match /ATTR\{ifalias\}="sriov-vf"/ }
+    end
+
+    describe 'systemd network configuration for unmanaged SR-IOV devices' do
+      subject { file('/etc/systemd/network/01-azure-sriov-unmanaged.network') }
+
+      it { should be_mode(644) }
+      it { should be_owned_by('root') }
+
+      its(:content) { should match /\[Match\]/ }
+      its(:content) { should match /Property=AZURE_UNMANAGED_SRIOV=1/ }
+      its(:content) { should match /\[Link\]/ }
+      its(:content) { should match /Unmanaged=yes/ }
+    end
+  end
 end

--- a/stemcell_builder/stages/system_azure_network/apply.sh
+++ b/stemcell_builder/stages/system_azure_network/apply.sh
@@ -20,3 +20,11 @@ EOS
 # The port 65330 is unusable on Azure
 cp $dir/assets/90-azure-sysctl.conf $chroot/etc/sysctl.d
 chmod 0644 $chroot/etc/sysctl.d/90-azure-sysctl.conf
+
+# Install SR-IOV VF udev rule to mark network interfaces as unmanaged and set ifalias
+cp $dir/assets/10-azure-sriov-unmanaged.rules $chroot/etc/udev/rules.d
+chmod 0644 $chroot/etc/udev/rules.d/10-azure-sriov-unmanaged.rules
+
+# Apply the systemd.network configuration, to ignore unmanaged devices
+cp $dir/assets/01-azure-sriov-unmanaged.network $chroot/etc/systemd/network
+chmod 0644 $chroot/etc/systemd/network/01-azure-sriov-unmanaged.network

--- a/stemcell_builder/stages/system_azure_network/assets/01-azure-sriov-unmanaged.network
+++ b/stemcell_builder/stages/system_azure_network/assets/01-azure-sriov-unmanaged.network
@@ -1,0 +1,11 @@
+# Azure VMs with accelerated networking may have MANA, mlx4, or mlx5 SR-IOV
+# devices which are transparently bonded to a synthetic hv_netvsc device.
+#
+# 10-azure-unmanaged-sriov.rules will mark these devices with
+# AZURE_UNMANAGED_SRIOV=1, allowing this configuration to set them as unmanaged.
+
+[Match]
+Property=AZURE_UNMANAGED_SRIOV=1
+
+[Link]
+Unmanaged=yes

--- a/stemcell_builder/stages/system_azure_network/assets/10-azure-sriov-unmanaged.rules
+++ b/stemcell_builder/stages/system_azure_network/assets/10-azure-sriov-unmanaged.rules
@@ -1,0 +1,19 @@
+# Azure VMs with accelerated networking may have MANA, mlx4, or mlx5 SR-IOV devices
+# which are transparently bonded to a synthetic hv_netvsc device.
+#
+# Mark devices with the IFF_SLAVE bit set as unmanaged devices:
+#   AZURE_UNMANAGED_SRIOV=1:     Custom tag to mark the interface as unmanaged in systemd-networkd (01-azure-sriov-unmanaged.network).
+#   ID_NET_MANAGED_BY=unmanaged: Standard tag for systemd-networkd (v255+).
+#   NM_UNMANAGED=1:              Tells NetworkManager to ignore the interface.
+#
+# Additionally, set an ifalias to allow the bosh-agent to ignore the device, as both
+# interfaces, the synthetic and the VF interface, share the same MAC address and only
+# the synthetic interface should be used by the application.
+
+SUBSYSTEM=="net", ACTION!="remove", KERNEL!="lo", \
+    DRIVERS=="mana|mlx4_core|mlx5_core", \
+    ATTR{flags}=="0x?[89ABCDEF]*", \
+    ENV{AZURE_UNMANAGED_SRIOV}="1", \
+    ENV{ID_NET_MANAGED_BY}="unmanaged", \
+    ENV{NM_UNMANAGED}="1", \
+    ATTR{ifalias}="sriov-vf"


### PR DESCRIPTION
## Overview

When running Linux on cloud VMs with accelerated networking (SR-IOV), it’s critical to distinguish synthetic (paravirtualized) network interfaces from Virtual Function (VF) interfaces (direct hardware virtualization). This ensures the application uses the correct NIC (usually the synthetic one) for stable operation.

The goal of this change is to determine if an interface is a VF (hardware SR-IOV) or a synthetic interface and mark the VF interface with an alias.

## Accelerated Networking Differences on Cloud Providers

- **Azure**: On Azure both the synthetic NIC and the VF appear concurrently in the guest OS for the same network connection, sharing the same MAC address. The Linux `hv_netvsc` driver “bonds” the VF to the synthetic interface behind the scenes: it enslaves the VF under the synthetic device and automatically swaps the data path to the VF when available. The synthetic interface remains the primary one for configuration, while traffic is offloaded to the VF transparently. According to [Azure’s documentation][accelerated-networking-docs-azure],
  
    > “Applications should interact only with the synthetic interface… (the VF is under the control of the synthetic interface)”.

    If an application or agent mistakenly uses the VF directly, it can cause issues, especially since the VF may disconnect during host maintenance (e.g. Azure live migration) while the synthetic NIC stays up.

- **AWS**: On AWS, only one interface is visible to the guest for each ENI. If [enhanced networking (SR-IOV)][aws-enhanced-networking] is enabled, that interface itself uses the VF driver (e.g. `ixgbevf`, or `ena` on newer instances). If enhanced networking is disabled or not supported, the same single interface uses a synthetic driver (Xen vif in the example). There is no second “paired” interface with the same MAC on AWS — the NIC is either synthetic or VF, not both at once.

## Solution

1. Use **udev** to mark the VF as unmanaged (this handles the OS/network config side – ensuring only the synthetic NIC is configured and considered "online").
2. Configure **systemd-networkd** to skip devices marked with `AZURE_UNMANAGED_SRIOV=1` by udev.
3. Use **udev** to set an `ifalias` on the VF as a clear indicator (especially for the  bosh-agent, and for human debugging).

> [!NOTE]
> Marking unmanaged ensures that no automatic scripts or services will configure the VF. It will not get an IP via DHCP, and it should not be waited on during boot (preventing delays). For instance, a [Red Hat bug report][redhat-bug] noted that without the rule, `NetworkManager-wait-online.service` could hang for ~90 seconds on Azure while waiting for the VF interface to be up.
>
> Marking an interface unmanaged by NM/networkd does not remove it from the kernel. It still exists and shows up in `/sys/class/net`. So a user-space program (like BOSH agent) that directly scans system interfaces will still see it. BOSH agent does not ask NetworkManager which interfaces are managed; it just looks at the NICs present and their MACs. Thus, unmanaged marking alone doesn’t stop BOSH from confusing the VF for the primary, but combined with the agent’s [updated logic][bosh-agent-change] it will use the correct NIC.

## How to validate the solution works?

**Prerequisites**:

1. BOSH Director on Azure
2. Custom ubuntu-jammy stemcell which includes the [`fix`][stemcell-change] in bosh-linux-stemcell-builder and the [`fix`][bosh-agent-change] in the bosh-agent
3. Custom stemcell uploaded to the director
4. Test deployment referencing the custom stemcell and accelerated networking enabled

**What you should observe**:

- On the VMs you should see that in the `/sys/class/net/` directory, both interfaces are present, `eth0` and `eth1`. 

    ```sh
    $ ls /sys/class/net/ | grep eth
      eth0
      eth1
    ```

- Using `ethtool -i <interface name> | grep driver` command you can find out which one is the synthetic interface, based on the drivers. If the driver is hv_netvsc, it's the synthetic interface. The VF interface has a driver name that contains "mlx." The VF interface is also identifiable because its flags field includes `SLAVE`.

    ```sh
    $ ethtool -i eth0 | grep driver
      driver: hv_netvsc

    $ ethtool -i eth1 | grep driver
      driver: mlx5_core

    $ ip link | grep SLAVE
      3: eth1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq master eth0 state UP mode DEFAULT group default qlen 1000

- run `ip link` to verify the VF has the alias set:

    ```sh
    $ ip link | grep alias
      alias sriov-vf
    ```

- When you identified the synthetic interface, let's say it's `eth0`, make sure there is a systemd-networkd config in `/etc/systemd/network/` for that interface.

    ```sh
    $ ls /etc/systemd/network/ | grep eth0
      10_eth0.network
    ```

- You can also verify in the bosh-agent logs that the bosh-agent ignores the VF interface:

    ```sh
    $ zgrep "sriov-vf" /var/vcap/bosh/log/*
      /var/vcap/bosh/log/@4000000068e933d41e319b4c.s:2025-10-10_16:26:48.49426 sriov-vf
      /var/vcap/bosh/log/@4000000068e933d41e319b4c.s:2025-10-10_16:26:48.49427 [MacAddressDetector] 2025/10/10 16:26:48 DEBUG - Ignoring SR-IOV VF interface: eth1 (ifalias: sriov-vf)
    ```

## References

- [azure-vm-utils][az-vm-utils] - this package uses udev rules to mark Azure VFs similarly to the proposal

## Related

- Resolves cloudfoundry/bosh-agent#366
- Relates to cloudfoundry/bosh-agent#374

[stemcell-change]: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/532b8f6cda1ea59c7f71989a505207771ab87c2f
[bosh-agent-change]: https://github.com/cloudfoundry/bosh-agent/pull/374
[redhat-bug]: https://issues.redhat.com/browse/RHEL-15222
[aws-enhanced-networking]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sriov-networking.html
[az-vm-utils]: https://github.com/Azure/azure-vm-utils/tree/main
[accelerated-networking-docs-azure]: https://learn.microsoft.com/en-us/azure/virtual-network/accelerated-networking-how-it-works#application-usage