### PR TITLE
Disable unnecessary floppy kernel module

### DIFF
--- a/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
@@ -83,4 +83,10 @@ shared_examples_for 'a Linux kernel module configured OS image' do
       its(:content) { should match 'install rds /bin/true' }
     end
   end
+
+  context 'prevent floppy module from being loaded' do
+    describe file('/etc/modprobe.d/blacklist.conf') do
+      its(:content) { should match 'install floppy /bin/true' }
+    end
+  end
 end

--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -19,6 +19,7 @@ install hfsplus /bin/true
 install squashfs /bin/true
 install udf /bin/true
 install rds /bin/true
+install floppy /bin/true
 options ipv6 disable=1' >> $chroot/etc/modprobe.d/blacklist.conf
 
 echo '# prevent nouveau from loading


### PR DESCRIPTION
This PR removes loading of the legacy floppy module from the stemcell build.

Rationale:

- Module is obsolete hardware support; keeping it expands kernel attack surface (extra code paths, potential low‑severity but chronic CVEs).
- Azure (including Hyper-V) presents no virtual floppy device; upstream guidance (Microsoft LISA [core test suite](https://github.com/microsoft/lisa/blob/main/lisa/microsoft/testsuites/core/floppy.py)) explicitly expects/assumes floppy is absent.
- Eliminates pointless udev/probing delays and reduces initramfs/kernel footprint for slightly faster, cleaner boot.