### PR TITLE
Set correct expectations for Azure SRIOV specs

### DIFF
--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -56,11 +56,11 @@ describe 'Azure Stemcell', stemcell_image: true do
     describe 'SR-IOV VF udev rules' do
       subject { file('/etc/udev/rules.d/10-azure-sriov-unmanaged.rules') }
 
-      it { should be_mode(644) }
+      it { should be_mode(0644) }
       it { should be_owned_by('root') }
 
       its(:content) { should match /SUBSYSTEM=="net"/ }
-      its(:content) { should match /ATTR\{flags\}=="0\?\?\[89ABCDEF\]\*"/ }
+      its(:content) { should match /ATTR\{flags\}=="0x\?\[89ABCDEF\]\*"/ }
       its(:content) { should match /ENV\{AZURE_UNMANAGED_SRIOV\}="1"/ }
       its(:content) { should match /ENV\{ID_NET_MANAGED_BY\}="unmanaged"/ }
       its(:content) { should match /ENV\{NM_UNMANAGED\}="1"/ }
@@ -70,7 +70,7 @@ describe 'Azure Stemcell', stemcell_image: true do
     describe 'systemd network configuration for unmanaged SR-IOV devices' do
       subject { file('/etc/systemd/network/01-azure-sriov-unmanaged.network') }
 
-      it { should be_mode(644) }
+      it { should be_mode(0644) }
       it { should be_owned_by('root') }
 
       its(:content) { should match /\[Match\]/ }


### PR DESCRIPTION
This fix relates to: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/443, which [broke the ci](https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/stemcells-ubuntu-jammy/jobs/build-azure-hyperv/builds/430).

Tests are passing now:

```sh
$ STEMCELL_IMAGE=/mnt/stemcells/azure/hyperv/ubuntu/work/work/azure-hyperv-ubuntu.raw STEMCELL_WORKDIR=/mnt/stemcells/azure/hyperv/ubuntu/work/work STEMCELL_INFRASTRUCTURE=azure OS_NAME=ubuntu OS_VERSION=jammy bundle exec rspec --tag ~exclude_on_azure spec/stemcells/azure_spec.rb 
Run options:
  include {:stemcell_image=>true, :os_image=>true}
  exclude {:shellout_types=>true, :exclude_on_azure=>true}
/dev/loop0
add map loop0p1 (252:0): 0 9997984 linear 7:0 63
..........................del devmap : loop0p1


Finished in 0.45054 seconds (files took 0.10238 seconds to load)
26 examples, 0 failures
```