### PR TITLE
Add Hyper-V KVP Daemon to Azure Stemcells

### DIFF
--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -79,4 +79,25 @@ describe 'Azure Stemcell', stemcell_image: true do
       its(:content) { should match /Unmanaged=yes/ }
     end
   end
+
+  context 'installed by system_azure_init', {
+    exclude_on_alicloud: true,
+    exclude_on_aws: true,
+    exclude_on_google: true,
+    exclude_on_vcloud: true,
+    exclude_on_vsphere: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+    exclude_on_softlayer: true,
+  } do
+    describe 'Hyper-V KVP daemon' do
+      describe command('which hv_kvp_daemon') do
+        its(:exit_status) { should eq 0 }
+      end
+
+      describe service('hv-kvp-daemon') do
+        it { should be_enabled }
+      end
+    end
+  end
 end

--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -99,5 +99,20 @@ describe 'Azure Stemcell', stemcell_image: true do
         it { should be_enabled }
       end
     end
+
+    describe 'WALinuxAgent configuration' do
+      describe file('/etc/waagent.conf') do
+        it { should be_owned_by('root') }
+      end
+
+      describe file('/lib/systemd/system/walinuxagent.service') do
+        it { should be_mode(0644) }
+        it { should be_owned_by('root') }
+      end
+
+      describe service('walinuxagent') do
+        it { should be_enabled }
+      end
+    end
   end
 end

--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -5,7 +5,8 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 cloud-init"
+packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 \
+cloud-init linux-cloud-tools-common linux-cloud-tools-generic"
 pkg_mgr install $packages
 
 wala_release=2.14.0.1
@@ -67,6 +68,5 @@ cat $chroot/etc/rsyslog.d/21-cloudinit.conf >> $chroot/etc/rsyslog.d/50-default.
 rm $chroot/etc/rsyslog.d/21-cloudinit.conf
 
 
-# Installing Hyper-V KVP daemon via linux-cloud-tools
-pkg_mgr install "linux-cloud-tools-common linux-cloud-tools-generic"
+# Enable Hyper-V KVP daemon (installed via linux-cloud-tools)
 run_in_chroot "$chroot" "systemctl enable hv-kvp-daemon.service"

--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -66,3 +66,7 @@ cat $chroot/etc/rsyslog.d/21-cloudinit.conf >> $chroot/etc/rsyslog.d/50-default.
 
 rm $chroot/etc/rsyslog.d/21-cloudinit.conf
 
+
+# Installing Hyper-V KVP daemon via linux-cloud-tools
+pkg_mgr install "linux-cloud-tools-common linux-cloud-tools-generic"
+run_in_chroot "$chroot" "systemctl enable hv-kvp-daemon.service"


### PR DESCRIPTION
### Summary

Azure runs on the Hyper-V hypervisor, and Linux VMs rely on Linux Integration
Services (LIS) to communicate with the host. These services include kernel
modules (like hv_utils) and daemons (hv_kvp_daemon, hv_vss_daemon, etc.) that
handle e.g. Host-to-guest communication or VM metadata exchange.

The `hv_kvp_daemon` specifically manages key-value pair exchange between the
Azure host and the Linux guest. If the daemon is missing, Azure may not
be able to retrieve guest metadata (e.g., hostname, IP address) This can
affect Azure Resource Graph queries, scripts that rely on guest-reported
data, backup and monitoring tools that use KVP for coordination

### Symptoms

cloud-init writes warnings about events that could not be sent to hv-kvp:

```txt
$ grep kvp /var/log/cloud-init.log
failed to truncate kvp pool file, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
failed posting events to kvp, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
...
```

### Self-validation

#### 1. Run azure specs

<details>
<summary><code>azure_spec.rb</code></summary>

```sh
$ cd /opt/bosh/bosh-stemcell; STEMCELL_IMAGE=/mnt/stemcells/azure/hyperv/ubuntu/work/work/azure-hyperv-ubuntu.raw STEMCELL_WORKDIR=/mnt/stemcells/azure/hyperv/ubuntu/work/work/chroot OS_NAME=ubuntu bundle exec rspec spec/stemcells/azure_spec.rb
Run options:
  include {:stemcell_image=>true, :os_image=>true}
  exclude {:shellout_types=>true}
/dev/loop5
add map loop5p1 (252:0): 0 9997984 linear 7:5 63
................................del devmap : loop5p1


Finished in 0.54383 seconds (files took 0.10489 seconds to load)
32 examples, 0 failures
```
</details>

#### 2. Validate cloud-init logs

Deployed custom stemcell based on this branch and checked the cloud-init logs. It no longer includes warnings about kvp and the systemd service is running:

<details>
<summary><code>systemctl status hv-kvp-daemon.service</code></summary>

```sh
● hv-kvp-daemon.service - Hyper-V KVP Protocol Daemon
     Loaded: loaded (/lib/systemd/system/hv-kvp-daemon.service; enabled; vendor preset: enabled)
     Active: active (running) since Sun 2025-11-09 17:10:38 UTC; 8min ago
   Main PID: 375 (hv_kvp_daemon)
      Tasks: 1 (limit: 9431)
     Memory: 2.5M
     CGroup: /system.slice/hv-kvp-daemon.service
             └─375 /usr/lib/linux-tools/5.15.0-161-generic/hv_kvp_daemon -n

Nov 09 17:10:38 bosh-stemcell systemd[1]: Started Hyper-V KVP Protocol Daemon.
Nov 09 17:10:38 bosh-stemcell KVP[375]: KVP starting; pid is:375
Nov 09 17:10:38 bosh-stemcell KVP[375]: KVP LIC Version: 3.1
```
</details>