### PR TITLE
Prevent kernel from auto-loading floppy

### DIFF
--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -30,3 +30,5 @@ alias nouveau off
 alias lbm-nouveau off' >> $chroot/etc/modprobe.d/blacklist-nouveau.conf
 
 rm -rf $chroot/lib/modules/*/kernel/zfs $chroot/usr/src/linux-headers-*/zfs
+
+run_in_chroot $chroot "update-initramfs -u -k all"


### PR DESCRIPTION
In a previous change (#449), loading the floppy module was disabled by redirecting the floppy command to true. However, Buffer I/O errors observed in the `dmesg` output indicate that the kernel is still attempting to load the floppy module when the hardware supports it.

```txt
blk_update_request: I/O error, dev fd0, sector 0 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 0
floppy0: disk absent or changed during operation
```

This suggests that during boot:
1. Kernel detects floppy controller hardware
2. udev/kernel auto-loads floppy module (install directive not active yet)
3. Floppy driver starts, finds no disk → I/O errors
4. install directive becomes active (too late!)

The blacklist in /etc/modprobe.d only affects modprobe after the root filesystem is active. If the initramfs contains a `floppy.ko` file and is not rebuilt after the blacklist has been applied, the initramfs auto-loads the floppy driver.
`update-initramfs` rebuilds the initramfs and includes the /etc/modprobe.d rules to the root fs.