### PR TITLE
Mount /sys in system_kernel_modules for initramfs generation

### DIFF
--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -31,4 +31,6 @@ alias lbm-nouveau off' >> $chroot/etc/modprobe.d/blacklist-nouveau.conf
 
 rm -rf $chroot/lib/modules/*/kernel/zfs $chroot/usr/src/linux-headers-*/zfs
 
+mount --bind /sys "$chroot/sys"
+add_on_exit "umount $chroot/sys"
 run_in_chroot $chroot "update-initramfs -u -k all"


### PR DESCRIPTION
The system_kernel_modules stage fails when running update-initramfs with FIPS kernels because the FIPS initramfs hooks require `/sys` to be mounted for hardware introspection when MODULES=dep is configured.

The `run_in_chroot` helper creates an isolated mount namespace via `unshare -m`, which does not mount `/sys`. This causes mkinitramfs to fail with "mkinitramfs: MODULES dep requires mounted sysfs on /sys" when the FIPS hooks attempt to scan hardware capabilities.

Mount `/sys` explicitly in `system_kernel_modules/apply.sh` before calling update-initramfs to ensure the kernel device model and driver information is available for initramfs generation.

#### Related

- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/454#issuecomment-3530504160

#### Alternative Solutions

We could also mount `/sys` directly in the `run_in_chroot` helper, as `/sys` is also mounted in other places:

```
❯ grep -r "mount.*bind.*sys" stemcell_builder/stages/
stemcell_builder/stages/base_fips_apt/apply.sh:mount --bind /sys "$chroot/sys"
stemcell_builder/stages/system_fips_kernel/apply.sh:mount --bind /sys "$chroot/sys"
stemcell_builder/stages/restore_apt_sources/apply.sh:mount --bind /sys "$chroot/sys"
stemcell_builder/stages/base_apt/apply.sh:mount --bind /sys "$chroot/sys"
```