### PR TITLE
Configure Azure Stemcells to Use Azure-Optimized APT Mirrors

### DIFF
--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -43,6 +43,18 @@ describe 'Azure Stemcell', stemcell_image: true do
     end
   end
 
+  context 'cloud-init Azure APT mirror configuration' do
+    describe file('/etc/cloud/cloud.cfg.d/90-azure-apt-sources.cfg') do
+      it { should be_file }
+      its(:content) { should include('http://azure.archive.ubuntu.com/ubuntu/') }
+    end
+
+    describe file('/etc/cloud/cloud.cfg') do
+      it { should be_file }
+      its(:content) { should include('apt-configure') }
+    end
+  end
+
   context 'installed by system_azure_network', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,

--- a/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/cloud.cfg
+++ b/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/cloud.cfg
@@ -10,6 +10,7 @@ cloud_init_modules:
  - update_etc_hosts
  - users-groups
  - ssh
+ - apt-configure
 cloud_config_modules:
  - ssh-import-id
  - set-passwords


### PR DESCRIPTION
## Summary

This change configures Azure stemcells to use Azure-optimized APT mirrors (`azure.archive.ubuntu.com`) instead of the default Ubuntu mirrors. This improves package download performance for VMs running on Azure infrastructure and satisfies the LISA test suite requirements for Azure image validation ([`verify_repository_installed`](https://github.com/microsoft/lisa/blob/92df7ca8b3fef447124809776a1a9b38416d2851/lisa/microsoft/testsuites/core/azure_image_standard.py#L754)).

While the Azure mirror configuration existed in `/etc/cloud/cloud.cfg.d/90-azure-apt-sources.cfg`, it was never applied because the `apt-configure` module was not enabled in cloud-init's module list. Cloud-init now automatically configures `/etc/apt/sources.list` to use Azure mirrors at VM boot time.

## Self Validation

```sh
$ echo "=== APT Sources ===" && \
  cat /etc/apt/sources.list && \
  echo -e "\n=== Cloud-init Status ===" && \
  sudo cloud-init status && \
  echo -e "\n=== APT Update (first 5 lines) ===" && \
  sudo apt-get update 2>&1 | grep -E "Hit|Get" | head -5
```

<details>
<summary><b>Before Changes</b></summary>

```sh
=== APT Sources ===
deb http://archive.ubuntu.com/ubuntu jammy main universe multiverse
deb http://archive.ubuntu.com/ubuntu jammy-updates main universe multiverse
deb http://security.ubuntu.com/ubuntu jammy-security main universe multiverse

=== Cloud-init Status ===
status: done

=== APT Update (first 5 lines) ===
Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Hit:2 https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy InRelease
Get:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Get:5 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [2,816 kB]
```
</details>

<details>
<summary><b>After Changes</b></summary>

```sh
=== APT Sources ===
## Note, this file is written by cloud-init on first boot of an instance
## modifications made here will not survive a re-bundle.
## if you wish to make changes you can:
## a.) add 'apt_preserve_sources_list: true' to /etc/cloud/cloud.cfg
##     or do the same in user-data
## b.) add sources in /etc/apt/sources.list.d
## c.) make changes to template file /etc/cloud/templates/sources.list.tmpl

# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
# newer versions of the distribution.
deb http://azure.archive.ubuntu.com/ubuntu/ jammy main restricted
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy main restricted

## Major bug fix updates produced after the final release of the
## distribution.
deb http://azure.archive.ubuntu.com/ubuntu/ jammy-updates main restricted
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy-updates main restricted

## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
## team. Also, please note that software in universe WILL NOT receive any
## review or updates from the Ubuntu security team.
deb http://azure.archive.ubuntu.com/ubuntu/ jammy universe
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy universe
deb http://azure.archive.ubuntu.com/ubuntu/ jammy-updates universe
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy-updates universe

## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
## team, and may not be under a free licence. Please satisfy yourself as to
## your rights to use the software. Also, please note that software in
## multiverse WILL NOT receive any review or updates from the Ubuntu
## security team.
deb http://azure.archive.ubuntu.com/ubuntu/ jammy multiverse
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy multiverse
deb http://azure.archive.ubuntu.com/ubuntu/ jammy-updates multiverse
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy-updates multiverse

## N.B. software from this repository may not have been tested as
## extensively as that contained in the main release, although it includes
## newer versions of some applications which may provide useful features.
## Also, please note that software in backports WILL NOT receive any review
## or updates from the Ubuntu security team.
deb http://azure.archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse

deb http://azure.archive.ubuntu.com/ubuntu/ jammy-security main restricted
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy-security main restricted
deb http://azure.archive.ubuntu.com/ubuntu/ jammy-security universe
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy-security universe
deb http://azure.archive.ubuntu.com/ubuntu/ jammy-security multiverse
# deb-src http://azure.archive.ubuntu.com/ubuntu/ jammy-security multiverse

=== Cloud-init Status ===
status: done

=== APT Update (first 5 lines) ===
Hit:1 http://azure.archive.ubuntu.com/ubuntu jammy InRelease
Get:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu jammy-backports InRelease [127 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Hit:5 https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu jammy InRelease
```
</details>

## Testing

<details>
<summary>RSpec Test Output</summary>

```bash
$ bundle exec rspec -fd --tag ~exclude_on_azure spec/stemcells/azure_spec.rb:46
Azure Stemcell
  cloud-init Azure APT mirror configuration
    /etc/cloud/cloud.cfg.d/90-azure-apt-sources.cfg
      is expected to be file
      content
        is expected to include "http://azure.archive.ubuntu.com/ubuntu/"
    /etc/cloud/cloud.cfg
      is expected to be file
      content
        is expected to include "apt-configure"
del devmap : loop22p1

Finished in 0.2043 seconds (files took 0.10017 seconds to load)
4 examples, 0 failures
```
</details>
