### PR TITLE
Add linux-cloud-tools to expected azure packages

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
@@ -3,6 +3,10 @@ python3-lib2to3
 python3-pyasn1
 python3-setuptools
 cloud-init
+linux-cloud-tools-5.15
+linux-cloud-tools-5.15-generic
+linux-cloud-tools-common
+linux-cloud-tools-generic
 netplan.io
 python-babel-localedata
 python3-attr


### PR DESCRIPTION
Fixes #453

Relates to build failure: https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/stemcells-ubuntu-jammy/jobs/build-azure-hyperv/builds/466