### PR TITLE
Update waagent to v2.15.0.1

### DIFF
--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -33,6 +33,7 @@ run_in_chroot $chroot "
   sudo rm -fr WALinuxAgent-${wala_release}
   rm wala.tar.gz
 "
+mkdir -p $chroot/var/log/azure
 cp -f $dir/assets/etc/waagent/waagent.conf $chroot/etc/waagent.conf
 cp -f $dir/assets/etc/waagent/walinuxagent.service $chroot/lib/systemd/system/walinuxagent.service
 chmod 0644 $chroot/lib/systemd/system/walinuxagent.service

--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -9,8 +9,8 @@ packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-pyt
 cloud-init linux-cloud-tools-common linux-cloud-tools-generic"
 pkg_mgr install $packages
 
-wala_release=2.14.0.1
-wala_expected_sha1=e8f30e34eedc9280531af1bb1af9efb53d1a1039
+wala_release=2.15.0.1
+wala_expected_sha1=155fd6f326a2bf2ff97b4ea2e2c83dc16a9c1768
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')

--- a/stemcell_builder/stages/system_azure_init/assets/etc/waagent/walinuxagent.service
+++ b/stemcell_builder/stages/system_azure_init/assets/etc/waagent/walinuxagent.service
@@ -7,7 +7,7 @@
 [Unit]
 Description=Azure Linux Agent
 
-After=network-online.target
+After=network-online.target cloud-init.service
 Wants=network-online.target sshd.service sshd-keygen.service
 
 ConditionFileIsExecutable=/usr/sbin/waagent
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/python3 -u /usr/sbin/waagent -daemon
 Restart=always
 Slice=azure.slice
 CPUAccounting=yes
+MemoryAccounting=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
 * upgrades waagent to the latest version
 * syncs the systemd config, which adds memory-accounting and a dependency
   to cloud-init.service, which ensures that the waagent.service does
   not start before cloud-init has finished.

<https://github.com/Azure/WALinuxAgent/blob/v2.15.0.1/init/ubuntu/walinuxagent.service>