### PR TITLE
Fix output of "nvme id-ctrl" to show vendor-specific fields for noble

### DIFF
--- a/stemcell_builder/stages/udev_aws_rules/assets/nvme-id
+++ b/stemcell_builder/stages/udev_aws_rules/assets/nvme-id
@@ -2,6 +2,6 @@
 
 device_name="$(echo -n "$1" | cut -d 'p' -f1)"
 partition_number="$(echo -n "$1" | sed -E "s#${device_name}p?##")"
-resolved_device_name=$(/usr/sbin/nvme id-ctrl -v "$1" | sed -n -E '/0000:/s/.*"([^.]+).*".*/\1/p')
+resolved_device_name=$(/usr/sbin/nvme id-ctrl -V "$1" | sed -n -E '/0000:/s/.*"([^.]+).*".*/\1/p')
 echo "${resolved_device_name}${partition_number}"
 


### PR DESCRIPTION
This change fixes https://github.com/cloudfoundry/bosh-deployment/issues/486 .

On noble the command changed compared to jammy. 
Jammy
```
# /usr/sbin/nvme id-ctrl -v "/dev/nvme1n1" | sed -n -E '/0000:/s/.*"([^.]+).*".*/\1/p'
sdb
```
Noble
```
# /usr/sbin/nvme id-ctrl -v "/dev/nvme1n1" | sed -n -E '/0000:/s/.*"([^.]+).*".*/\1/p'
```
This change is also documented here: 
https://manpages.ubuntu.com/manpages/jammy/man1/nvme-id-ctrl.1.html vs https://manpages.ubuntu.com/manpages/noble/man1/nvme-id-ctrl.1.html

Testing this on noble works succesfully:
```
# /usr/sbin/nvme id-ctrl -V "/dev/nvme1n1" | sed -n -E '/0000:/s/.*"([^.]+).*".*/\1/p'
sdb
```
