### PR TITLE
Add CloudInit step to vsphere agent settings

### DIFF
--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
@@ -16,6 +16,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
     "Settings": {
       "Sources": [
         {
+          "Type": "CloudInit"
+        }, {
           "Type": "CDROM",
           "FileName": "env"
         }


### PR DESCRIPTION
This allows the agent to fetch settings from cloudinit in vsphere instead of mounting the CD-ROM. Note that this change shouln't be merged until there is a compatible agent binary available.

[This CPI PR](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/pull/437) and [This agent PR](https://github.com/cloudfoundry/bosh-agent/pull/392) should both be merged, and we should have a new bosh-agent build before we make the stemcell change here.