### PR TITLE
Revert "Add CloudInit step to vsphere agent settings"

### DIFF
--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
@@ -16,8 +16,6 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
     "Settings": {
       "Sources": [
         {
-          "Type": "CloudInit"
-        }, {
           "Type": "CDROM",
           "FileName": "env"
         }


### PR DESCRIPTION
Reverts cloudfoundry/bosh-linux-stemcell-builder#463

As mentioned multiple times in that PR, it should NOT have been merged until the agent changes in https://github.com/cloudfoundry/bosh-agent/pull/392 have been released.  In addition, the value is going to be updated in https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/464.

Fixes https://github.com/cloudfoundry/bosh-vsphere-cpi-release/issues/439