### PR TITLE
Add VsphereGuestInfo settings source to noble stemcell

### DIFF
--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/assets/agent.json
@@ -10,6 +10,8 @@
     "Settings": {
       "Sources": [
         {
+          "Type": "VsphereGuestInfo"
+        }, {
           "Type": "CDROM",
           "FileName": "env"
         }


### PR DESCRIPTION
This allows the agent to fetch settings from guestinfo in vmware rpc in vsphere instead of mounting the CD-ROM. There is already a promoted bosh-agent available, so this change should be ready to merge.