### PR TITLE
Add cgroups v2 support for Jammy stemcells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ acceptance-tests/os-conf-release
 **/*.log
 
 ci/docker/VMware-ovftool-*.bundle
+tmp/

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -13,12 +13,32 @@
 monit_isolation_classid=2958295041
 
 permit_monit_access() {
-    net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk '{ print $2 }' )"
-    net_cls_subproc="$(grep net_cls /proc/self/cgroup | awk -F ":" '{ print $3 }' )"
-    monit_access_cgroup="${net_cls_location}/${net_cls_subproc}/monit-api-access"
+    if grep -q '^0::' /proc/self/cgroup 2>/dev/null; then
+        # cgroupv2 (unified hierarchy)
+        # Create a sub-cgroup under the current process's cgroup and move into it.
+        # The iptables rules match on this cgroup path.
+        cgroup_mount="$(awk '$3 == "cgroup2" { print $2 }' /proc/self/mounts)"
+        current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
+        if [ -z "${cgroup_mount}" ] || [ -z "${current_cgroup}" ]; then
+            echo "permit_monit_access: unable to resolve cgroup v2 mount or path" >&2
+            return 1
+        fi
+        monit_access_cgroup="${cgroup_mount}${current_cgroup}/monit-api-access"
 
-    mkdir -p "${monit_access_cgroup}"
-    echo "${monit_isolation_classid}" > "${monit_access_cgroup}/net_cls.classid"
+        mkdir -p "${monit_access_cgroup}"
+        echo $$ > "${monit_access_cgroup}/cgroup.procs"
+    else
+        # cgroupv1 - use net_cls classid
+        net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk '{ print $2 }')"
+        net_cls_subproc="$(grep net_cls /proc/self/cgroup | awk -F ":" '{ print $3 }')"
+        if [ -z "${net_cls_location}" ] || [ -z "${net_cls_subproc}" ]; then
+            echo "permit_monit_access: unable to resolve cgroup v1 net_cls location or path" >&2
+            return 1
+        fi
+        monit_access_cgroup="${net_cls_location}/${net_cls_subproc}/monit-api-access"
 
-    echo $$ > "${monit_access_cgroup}/tasks"
+        mkdir -p "${monit_access_cgroup}"
+        echo "${monit_isolation_classid}" > "${monit_access_cgroup}/net_cls.classid"
+        echo $$ > "${monit_access_cgroup}/tasks"
+    fi
 }

--- a/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
+++ b/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
@@ -2,13 +2,30 @@
 
 source /var/vcap/bosh/etc/monit-access-helper.sh
 
-if iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
-	    -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
-then
-  /bin/true
+if grep -q '^0::' /proc/self/cgroup 2>/dev/null; then
+    # cgroupv2: dynamically determine the cgroup path for this process.
+    # The agent calls permit_monit_access() to join the monit-api-access sub-cgroup.
+    current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
+    if [ -z "${current_cgroup}" ]; then
+        echo "restrict-monit-api-access: unable to resolve cgroup v2 path" >&2
+        exit 1
+    fi
+    cgroup_match="--path ${current_cgroup}/monit-api-access"
 else
+    # cgroupv1: use the classid from monit-access-helper.sh
+    cgroup_match="--cgroup ${monit_isolation_classid}"
+fi
+
+# Idempotently ensure both iptables rules exist.
+# The ACCEPT rule must be checked/inserted first so it appears above the DROP rule in the chain.
+if ! iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+        -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null; then
     iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
-	     -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
+        -m state --state ESTABLISHED,RELATED -j ACCEPT
+fi
+
+if ! iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+        -m cgroup ! ${cgroup_match} -j DROP 2>/dev/null; then
     iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
-	     -m state --state ESTABLISHED,RELATED -j ACCEPT
+        -m cgroup ! ${cgroup_match} -j DROP
 fi


### PR DESCRIPTION
This enables warden stemcells to function on hosts that are using cgroups v2, which is increasingly common. This should not have any effects on other infrastructures as the stemcell kernel will continue to be booted with cgroups v1.