### PR TITLE
Add Azure Gen2 and NVMe support for stemcells

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
@@ -188,7 +188,14 @@ module Bosh::Stemcell
       end
 
       def additional_cloud_properties
-        {'root_device_name' => '/dev/sda1'}
+        {
+          'root_device_name' => '/dev/sda1',
+          'generation' => 'gen2',
+          'accelerated_networking' => true,
+          'hibernation' => true,
+          'disk_controller_types' => ['scsi'],
+          'security_type' => 'TrustedLaunchSupported'
+        }
       end
     end
 

--- a/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
@@ -193,7 +193,7 @@ module Bosh::Stemcell
           'generation' => 'gen2',
           'accelerated_networking' => true,
           'hibernation' => true,
-          'disk_controller_types' => ['scsi'],
+          'disk_controller_types' => ['scsi', 'nvme'],
           'security_type' => 'TrustedLaunchSupported'
         }
       end

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
@@ -1,3 +1,4 @@
+azure-vm-utils
 cloud-init
 netplan.io
 python-is-python3

--- a/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
@@ -162,7 +162,14 @@ module Bosh::Stemcell
     it { should eq Infrastructure.for('azure') }
 
     it 'has azure specific additional cloud properties' do
-      expect(subject.additional_cloud_properties).to eq({'root_device_name' => '/dev/sda1'})
+      expect(subject.additional_cloud_properties).to eq({
+        'root_device_name' => '/dev/sda1',
+        'generation' => 'gen2',
+        'accelerated_networking' => true,
+        'hibernation' => true,
+        'disk_controller_types' => ['scsi'],
+        'security_type' => 'TrustedLaunchSupported'
+      })
     end
   end
 

--- a/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
@@ -167,7 +167,7 @@ module Bosh::Stemcell
         'generation' => 'gen2',
         'accelerated_networking' => true,
         'hibernation' => true,
-        'disk_controller_types' => ['scsi'],
+        'disk_controller_types' => ['scsi', 'nvme'],
         'security_type' => 'TrustedLaunchSupported'
       })
     end

--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -73,6 +73,11 @@ case "${stemcell_infrastructure}" in
 aws)
   grub_suffix="nvme_core.io_timeout=4294967295"
   ;;
+azure)
+  # For NVMe storage, Microsoft recommends setting nvme_core.io_timeout to 240 seconds
+  # to avoid IO timeouts and let Azure handle disk failures or interruptions.
+  grub_suffix="nvme_core.io_timeout=240"
+  ;;
 cloudstack)
   grub_suffix="console=hvc0"
   ;;

--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -5,7 +5,7 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 cloud-init"
+packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 cloud-init azure-vm-utils"
 pkg_mgr install $packages
 
 wala_release=2.9.1.1


### PR DESCRIPTION
### Summary

This PR enhances Azure stemcell images with Gen2 capabilities and NVMe storage support to enable compatibility with latest generation VM types (e.g., Dv6+).

The stemcell metadata have been extended for Azure and now include the following capabilities:
* `generation: gen2` - Marks image as Gen2 compatible
* `accelerated_networking: true` - Enables accelerated networking support
* `hibernation: true` - Enables hibernation capability
* `disk_controller_types: ['scsi', 'nvme']` - Supported disk controller types: This setting allows compatibility with older VM types (such as `Dv4`) that use SCSI, VM types that support both SCSI and NVMe (like `Dv5`), as well as newer VM types (for example, `Dv6`) that only support NVMe.
* `security_type: TrustedLaunchSupported` - Enables deployment of both standard VMs and TrustedLaunch VMs using the same image. For TrustedLaunch to work, addtional changes in the stemcell are required, which will be provided in a separate change.

> [!NOTE]
> The BOSH Azure CPI[^1] will parse and use the Azure-specific metadata to create Azure Compute Gallery Images with the features mentioned above. These features could not be configured with generation 1.

> [!NOTE]
> This change should be merged after the CPI change[^1], because the CPI already supports [reading the generation](https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/232d77cf4f80e04f750d1430fe2e68d11c8a3153/src/bosh_azure_cpi/lib/cloud/azure/stemcell/compute_gallery_manager.rb#L39C10-L39C13) from stemcell metadata, but is not yet capable to create proper generation v2 images and they would conflict if a noble stemcell image definition already exists in the ACG.

Additionally, this PR introduces NVMe configuration specifically for Azure:

- NVMe I/O timeout (`nvme_core.io_timeout=240`) in GRUB settings as [recommended by Microsoft](https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-interface#supported-linux-os-images) to avoid I/O timeouts and let Azure handle disk failures
- [`azure-vm-utils`](https://github.com/Azure/azure-vm-utils) package: includes udev rules for NVMe disks and SR-IOV interfaces. Previously, SR-IOV udev rules were manually created[^2] in the stemcell, but with this package, manual creation and ongoing maintenance are no longer needed.

### Testing

After this change, the `stemcell.MF` looks like this:

```
tar -Oxzf tmp/bosh-stemcell-4.0.10-azure-hyperv-ubuntu-noble.tgz stemcell.MF
---
name: bosh-azure-hyperv-ubuntu-noble
version: 4.0.10
bosh_protocol: 1
api_version: 3
sha1: f881420ba6f08641e1bbc9854d14c5284b7f2cbd
operating_system: ubuntu-noble
stemcell_formats:
- azure-vhd
cloud_properties:
  name: bosh-azure-hyperv-ubuntu-noble
  version: 4.0.10
  infrastructure: azure
  hypervisor: hyperv
  disk: 5120
  disk_format: vhd
  container_format: bare
  os_type: linux
  os_distro: ubuntu
  architecture: x86_64
  root_device_name: "/dev/sda1"
  generation: gen2
  accelerated_networking: true
  hibernation: true
  disk_controller_types:
  - scsi
  - nvme
  security_type: TrustedLaunchSupported
```

### Related Issues

https://github.com/cloudfoundry/bosh-azure-cpi-release/issues/706

[^1]: https://github.com/cloudfoundry/bosh-azure-cpi-release/pull/734
[^2]: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/443