### PR TITLE
Add lun resolver configuration

### DIFF
--- a/stemcell_builder/stages/bosh_azure_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_azure_agent_settings/assets/agent.json
@@ -3,6 +3,7 @@
     "Linux": {
       "CreatePartitionIfNoEphemeralDisk": true,
       "DevicePathResolutionType": "scsi",
+      "LunDeviceSymlinkPath": "/dev/disk/azure/data/by-lun",
       "PartitionerType": "parted",
       "ServiceManager": "systemd"
     }


### PR DESCRIPTION
Configures the bosh-agent to use the new `LunDeviceSymlinkPath` resolver.

Depends on:
- https://github.com/cloudfoundry/bosh-agent/pull/402
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/469
