### PR TITLE
Prevent systemd-binfmt from running in containers

### DIFF
--- a/stemcell_builder/stages/bosh_systemd/apply.sh
+++ b/stemcell_builder/stages/bosh_systemd/apply.sh
@@ -12,3 +12,14 @@ source $base_dir/lib/prelude_bosh.bash
 run_in_chroot $chroot "
 echo 'RemoveIPC=no' >> /etc/systemd/logind.conf
 "
+
+# Prevent systemd-binfmt from running in containers.
+# When running in a privileged container (e.g., Docker CPI on Apple Silicon),
+# this service clears the host's binfmt_misc registrations (including Rosetta),
+# causing "exec format error" for all subsequent x86_64 processes.
+mkdir -p $chroot/etc/systemd/system/systemd-binfmt.service.d
+
+cat > $chroot/etc/systemd/system/systemd-binfmt.service.d/skip-in-container.conf <<EOF
+[Unit]
+ConditionVirtualization=!container
+EOF


### PR DESCRIPTION
extracting from https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/468#issuecomment-3891802803

When stemcells run as privileged containers (e.g., Docker CPI on Apple Silicon), systemd-binfmt clears the host's binfmt_misc registrations, including Rosetta, causing "exec format error" for x86_64 processes.

Add a drop-in override with ConditionVirtualization=!container to skip the service in containers while preserving normal behavior on VMs.

related to https://github.com/cloudfoundry/bosh-deployment/issues/497