### PR TITLE
Use bosh-agent enable-monit-access if available

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -1,0 +1,3 @@
+permit_monit_access() {
+  /var/vcap/bosh/bin/bosh-agent enable-monit-access
+}


### PR DESCRIPTION
monit-access-helper will use "enable-monit-access" bosh-agent command if it is available and nftables tool is present. Otherwise fall back to old monit cgroup access setup.

This PR requires https://github.com/cloudfoundry/bosh-agent/pull/406  