### PR TITLE
Forward‑porting Azure-related changes from Jammy to Noble

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
@@ -1,5 +1,9 @@
 azure-vm-utils
 cloud-init
+linux-cloud-tools-5.15
+linux-cloud-tools-5.15-generic
+linux-cloud-tools-common
+linux-cloud-tools-generic
 netplan.io
 python-is-python3
 python3-attr

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
@@ -1,7 +1,7 @@
 azure-vm-utils
 cloud-init
-linux-cloud-tools-5.15
-linux-cloud-tools-5.15-generic
+linux-cloud-tools-6.8
+linux-cloud-tools-6.8-generic
 linux-cloud-tools-common
 linux-cloud-tools-generic
 netplan.io

--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -40,4 +40,25 @@ describe 'Azure Stemcell', stemcell_image: true do
       its(:content) { should include('"PartitionerType": "parted"') }
     end
   end
+
+  context 'installed by system_azure_init', {
+    exclude_on_alicloud: true,
+    exclude_on_aws: true,
+    exclude_on_google: true,
+    exclude_on_vcloud: true,
+    exclude_on_vsphere: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+    exclude_on_softlayer: true,
+  } do
+    describe 'Hyper-V KVP daemon' do
+      describe command('which hv_kvp_daemon') do
+        its(:exit_status) { should eq 0 }
+      end
+
+      describe service('hv-kvp-daemon') do
+        it { should be_enabled }
+      end
+    end
+  end
 end

--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -60,5 +60,20 @@ describe 'Azure Stemcell', stemcell_image: true do
         it { should be_enabled }
       end
     end
+
+    describe 'WALinuxAgent configuration' do
+      describe file('/etc/waagent.conf') do
+        it { should be_owned_by('root') }
+      end
+
+      describe file('/lib/systemd/system/walinuxagent.service') do
+        it { should be_mode(0644) }
+        it { should be_owned_by('root') }
+      end
+
+      describe service('walinuxagent') do
+        it { should be_enabled }
+      end
+    end
   end
 end

--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -41,6 +41,18 @@ describe 'Azure Stemcell', stemcell_image: true do
     end
   end
 
+  context 'cloud-init Azure APT mirror configuration' do
+    describe file('/etc/cloud/cloud.cfg.d/90-azure-apt-sources.cfg') do
+      it { should be_file }
+      its(:content) { should include('http://azure.archive.ubuntu.com/ubuntu/') }
+    end
+
+    describe file('/etc/cloud/cloud.cfg') do
+      it { should be_file }
+      its(:content) { should include('apt-configure') }
+    end
+  end
+
   context 'installed by system_azure_init', {
     exclude_on_alicloud: true,
     exclude_on_aws: true,

--- a/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
@@ -78,4 +78,10 @@ shared_examples_for 'a Linux kernel module configured OS image' do
       its(:content) { should match 'install rds /bin/true' }
     end
   end
+
+  context 'prevent floppy module from being loaded' do
+    describe file('/etc/modprobe.d/blacklist.conf') do
+      its(:content) { should match 'install floppy /bin/true' }
+    end
+  end
 end

--- a/stemcell_builder/stages/bosh_azure_chrony/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_chrony/apply.sh
@@ -6,7 +6,7 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
-mkdir -p /etc/systemd/system/chrony.service.d
+mkdir -p $chroot/etc/systemd/system/chrony.service.d
 
 cat > $chroot/etc/systemd/system/chrony.service.d/chrony-systemd-override.conf <<EOF
 # created by $0

--- a/stemcell_builder/stages/bosh_azure_chrony/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_chrony/apply.sh
@@ -6,8 +6,24 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
+mkdir -p /etc/systemd/system/chrony.service.d
+
+cat > $chroot/etc/systemd/system/chrony.service.d/chrony-systemd-override.conf <<EOF
+# created by $0
+[Service]
+# Set the CPU scheduling policy to FIFO (First-In, First-Out), a real-time policy.
+CPUSchedulingPolicy=fifo
+
+# Set the real-time priority to the highest possible value (99).
+# This ensures chronyd runs before any other non-kernel, non-real-time tasks.
+CPUSchedulingPriority=50
+
+# Make the process less likely to be killed by the OOM killer
+OOMScoreAdjust=-500
+EOF
+
 cat > $chroot/etc/chrony/conf.d/azure_ptp.conf <<EOF
 # created by $0
 # https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
-refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0 stratum 2
+refclock PHC /dev/ptp_hyperv poll -1 dpoll -2 offset 0 stratum 2
 EOF

--- a/stemcell_builder/stages/bosh_azure_chrony/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_chrony/apply.sh
@@ -9,5 +9,5 @@ source $base_dir/lib/prelude_bosh.bash
 cat > $chroot/etc/chrony/conf.d/azure_ptp.conf <<EOF
 # created by $0
 # https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
-refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0 stratum 2
 EOF

--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -33,6 +33,7 @@ run_in_chroot $chroot "
   sudo rm -fr WALinuxAgent-${wala_release}
   rm wala.tar.gz
 "
+mkdir -p $chroot/var/log/azure
 cp -f $dir/assets/etc/waagent/waagent.conf $chroot/etc/waagent.conf
 cp -f $dir/assets/etc/waagent/walinuxagent.service $chroot/lib/systemd/system/walinuxagent.service
 chmod 0644 $chroot/lib/systemd/system/walinuxagent.service

--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -9,8 +9,8 @@ packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-pyt
 cloud-init azure-vm-utils linux-cloud-tools-common linux-cloud-tools-generic"
 pkg_mgr install $packages
 
-wala_release=2.9.1.1
-wala_expected_sha1=b61bd57f3b2f7b048d6bab2739690bbf1d9c213b
+wala_release=2.15.0.1
+wala_expected_sha1=155fd6f326a2bf2ff97b4ea2e2c83dc16a9c1768
 
 curl -L https://github.com/Azure/WALinuxAgent/archive/v${wala_release}.tar.gz > /tmp/wala.tar.gz
 sha1=$(cat /tmp/wala.tar.gz | openssl dgst -sha1  | awk 'BEGIN {FS="="}; {gsub(/ /,"",$2); print $2}')

--- a/stemcell_builder/stages/system_azure_init/apply.sh
+++ b/stemcell_builder/stages/system_azure_init/apply.sh
@@ -5,7 +5,8 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 cloud-init azure-vm-utils"
+packages="python3 python3-pyasn1 python3-setuptools python3-distro python-is-python3 \
+cloud-init azure-vm-utils linux-cloud-tools-common linux-cloud-tools-generic"
 pkg_mgr install $packages
 
 wala_release=2.9.1.1
@@ -70,3 +71,6 @@ cat $chroot/etc/rsyslog.d/21-cloudinit.conf >> $chroot/etc/rsyslog.d/50-default.
 
 rm $chroot/etc/rsyslog.d/21-cloudinit.conf
 
+
+# Enable Hyper-V KVP daemon (installed via linux-cloud-tools)
+run_in_chroot "$chroot" "systemctl enable hv-kvp-daemon.service"

--- a/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/05-logging.cfg
+++ b/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/05-logging.cfg
@@ -1,7 +1,7 @@
-=## This yaml formated config file handles setting
+## This yaml formatted config file handles setting
 ## logger information.  The values that are necessary to be set
 ## are seen at the bottom.  The top '_log' are only used to remove
-## redundency in a syslog and fallback-to-file case.
+## redundancy in a syslog and fallback-to-file case.
 ##
 ## The 'log_cfgs' entry defines a list of logger configs
 ## Each entry in the list is tried, and the first one that
@@ -69,4 +69,3 @@ log_cfgs:
 # 'tee -a /var/log/cloud-init-output.log' so the user can see output
 # there without needing to look on the console.
 output: {all: '| tee -a /var/log/cloud-init-output.log'}
-

--- a/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/cloud.cfg
+++ b/stemcell_builder/stages/system_azure_init/assets/etc/cloud-init/cloud.cfg
@@ -10,6 +10,7 @@ cloud_init_modules:
  - update_etc_hosts
  - users-groups
  - ssh
+ - apt-configure
 cloud_config_modules:
  - ssh-import-id
  - set-passwords

--- a/stemcell_builder/stages/system_azure_init/assets/etc/waagent/walinuxagent.service
+++ b/stemcell_builder/stages/system_azure_init/assets/etc/waagent/walinuxagent.service
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/python3 -u /usr/sbin/waagent -daemon
 Restart=always
 Slice=azure.slice
 CPUAccounting=yes
+MemoryAccounting=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -29,3 +29,5 @@ alias nouveau off
 alias lbm-nouveau off' >> $chroot/etc/modprobe.d/blacklist-nouveau.conf
 
 rm -rf $chroot/lib/modules/*/kernel/zfs $chroot/usr/src/linux-headers-*/zfs
+
+run_in_chroot $chroot "update-initramfs -u -k all"

--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -30,4 +30,6 @@ alias lbm-nouveau off' >> $chroot/etc/modprobe.d/blacklist-nouveau.conf
 
 rm -rf $chroot/lib/modules/*/kernel/zfs $chroot/usr/src/linux-headers-*/zfs
 
+mount --bind /sys "$chroot/sys"
+add_on_exit "umount $chroot/sys"
 run_in_chroot $chroot "update-initramfs -u -k all"

--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -18,7 +18,8 @@ install hfs /bin/true
 install hfsplus /bin/true
 install squashfs /bin/true
 install udf /bin/true
-install rds /bin/true' >> $chroot/etc/modprobe.d/blacklist.conf
+install rds /bin/true
+install floppy /bin/true' >> $chroot/etc/modprobe.d/blacklist.conf
 
 echo '# prevent nouveau from loading
 blacklist nouveau


### PR DESCRIPTION
To keep the Noble stemcell aligned with recent fixes introduced in Jammy, this PR forward‑ports the following changes to the Noble branch using cherry‑picks.

### Included pull requests

- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/438
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/442
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/441
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/449
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/454
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/455
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/453
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/457
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/456
- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/461

> [!NOTE]
> There is no need to forward-port #443, because the SRIOV-udev rules are already included in the `azure-vm-utils` package, which was added to Noble as part of #469.

Resolves #450