### PR TITLE
Update dpkg list for rsyslog deps

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -287,6 +287,7 @@ libpolkit-agent-1-0:amd64
 libpolkit-gobject-1-0:amd64
 libpopt0:amd64
 libprocps8:amd64
+libprotobuf-c1:amd64
 libpsl5:amd64
 libpython3-stdlib:amd64
 libpython3.10-minimal:amd64
@@ -311,6 +312,7 @@ libsgutils2-2:amd64
 libsigsegv2:amd64
 libslang2:amd64
 libsmartcols1:amd64
+libsnappy1v5:amd64
 libsource-highlight-common
 libsource-highlight4v5
 libsqlite3-0:amd64


### PR DESCRIPTION
As of https://www.rsyslog.com/rsyslog-8-2602-0-rosi-collector-rate-limit-policies-stronger-tls-and-telemetry-integration/ rsyslog now requires the libprotobuf-c1:amd64 and libsnappy1v5:amd64 packages (see "New Dependencies")