### PR TITLE
jammy: Add bosh-enable-monit-access hard link

### DIFF
--- a/stemcell_builder/stages/bosh_go_agent/apply.sh
+++ b/stemcell_builder/stages/bosh_go_agent/apply.sh
@@ -35,6 +35,7 @@ bosh_agent_version=$(cat ${assets_dir}/bosh-agent-version)
 /usr/bin/meta4 file-download --metalink=${assets_dir}/metalink.meta4 --file=bosh-agent-${bosh_agent_version}-linux-amd64 bosh-agent
 
 mv bosh-agent $chroot/var/vcap/bosh/bin/
+ln --force $chroot/var/vcap/bosh/bin/bosh-agent $chroot/var/vcap/bosh/etc/bosh-enable-monit-access
 
 cp $assets_dir/bosh-agent-rc $chroot/var/vcap/bosh/bin/bosh-agent-rc
 

--- a/stemcell_builder/stages/bosh_monit/apply.sh
+++ b/stemcell_builder/stages/bosh_monit/apply.sh
@@ -29,3 +29,5 @@ chmod 0700 $chroot/$bosh_dir/etc/monitrc
 # monit refuses to start without an include file present
 mkdir -p $chroot/$bosh_app_dir/monit
 touch $chroot/$bosh_app_dir/monit/empty.monitrc
+
+cp $dir/assets/monit-access-helper.sh $chroot/$bosh_dir/etc/

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -1,3 +1,3 @@
 permit_monit_access() {
-  /var/vcap/bosh/bin/bosh-agent enable-monit-access
+  /var/vcap/bosh/etc/bosh-enable-monit-access
 }


### PR DESCRIPTION
* Use bosh-enable-monit-access bosh agent binary call. See https://github.com/cloudfoundry/bosh-agent/pull/409
* Also provide monit-access-helper.sh in /var/vcap/bosh/etc for older releases for backwards compatibility