### PR TITLE
Run bosh-enable-monit-access as vcap if called by root

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -1,3 +1,7 @@
 permit_monit_access() {
-  /var/vcap/bosh/etc/bosh-enable-monit-access
+  if [ "$(id -u)" -eq 0 ]; then
+    sudo -u vcap /var/vcap/bosh/etc/bosh-enable-monit-access
+  else
+    /var/vcap/bosh/etc/bosh-enable-monit-access
+  fi
 }


### PR DESCRIPTION
Rules for root are already set by bosh agent. Set for vcap user for backwards compatiblity with old releases that just called the helper script.