### PR TITLE
Use bosh-enable-monit-access if available and fallback to nftables setup

### DIFF
--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -9,7 +9,7 @@ source $base_dir/etc/settings.bash
 debs="libssl-dev lsof strace bind9-host dnsutils tcpdump iputils-arping \
 curl wget bison libreadline6-dev rng-tools \
 libxml2 libxml2-dev libxslt1.1 libxslt1-dev zip unzip \
-flex psmisc apparmor-utils iptables sysstat \
+flex psmisc apparmor-utils iptables nftables sysstat \
 rsync openssh-server traceroute libncurses5-dev quota \
 libaio1 gdb libcap2-bin libcap2-dev libbz2-dev \
 cmake uuid-dev libgcrypt-dev ca-certificates \

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -1,3 +1,13 @@
 permit_monit_access() {
-  /var/vcap/bosh/etc/bosh-enable-monit-access
+  local vcap_uid
+  vcap_uid="$(id -u vcap)"
+
+  if ! /var/vcap/bosh/etc/bosh-enable-monit-access "$vcap_uid" 2>/dev/null; then
+    if nft list chain inet bosh_agent monit_access_jobs &>/dev/null; then
+      if ! nft list chain inet bosh_agent monit_access_jobs 2>/dev/null | grep -q "skuid $vcap_uid"; then
+        nft add rule inet bosh_agent monit_access_jobs \
+          meta skuid "$vcap_uid" ip daddr 127.0.0.1 tcp dport 2822 accept
+      fi
+    fi
+  fi
 }


### PR DESCRIPTION
Use bosh-enable-monit-access. If it fails then fall back to setting nft rules for vcap user.

This change is required for backwards compatibility with old releases that source the script but don't have exec access to it.

The change also requires https://github.com/cloudfoundry/bosh-agent/pull/416