### PR TITLE
[ubuntu-jammy] Move bosh-enable-monit-access helper to /usr/local/sbin

### DIFF
--- a/stemcell_builder/stages/bosh_go_agent/apply.sh
+++ b/stemcell_builder/stages/bosh_go_agent/apply.sh
@@ -35,7 +35,7 @@ bosh_agent_version=$(cat ${assets_dir}/bosh-agent-version)
 /usr/bin/meta4 file-download --metalink=${assets_dir}/metalink.meta4 --file=bosh-agent-${bosh_agent_version}-linux-amd64 bosh-agent
 
 mv bosh-agent $chroot/var/vcap/bosh/bin/
-ln --force $chroot/var/vcap/bosh/bin/bosh-agent $chroot/var/vcap/bosh/etc/bosh-enable-monit-access
+ln --force $chroot/var/vcap/bosh/bin/bosh-agent $chroot/usr/local/sbin/bosh-enable-monit-access
 
 cp $assets_dir/bosh-agent-rc $chroot/var/vcap/bosh/bin/bosh-agent-rc
 

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -1,3 +1,3 @@
 permit_monit_access() {
-  /var/vcap/bosh/etc/bosh-enable-monit-access
+  /usr/local/sbin/bosh-enable-monit-access
 }


### PR DESCRIPTION
Enables access for legacy bosh-releases that setup monit access via the monit-access-helper.sh script and may not have executable access to binaries under /var/vcap/bosh/