### PR TITLE
Add nftables binary

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -223,6 +223,7 @@ libipt2
 libisc-export1105:amd64
 libisl23:amd64
 libitm1:amd64
+libjansson4:amd64
 libjson-c5:amd64
 libjsoncpp25:amd64
 libk5crypto3:amd64
@@ -257,6 +258,7 @@ libnetplan0:amd64
 libnettle8:amd64
 libnewt0.52:amd64
 libnfnetlink0:amd64
+libnftables1:amd64
 libnftnl11:amd64
 libnghttp2-14:amd64
 libnl-3-200:amd64
@@ -377,6 +379,7 @@ net-tools
 netbase
 netcat-openbsd
 networkd-dispatcher
+nftables
 nvme-cli
 openssh-client
 openssh-server

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -16,7 +16,8 @@ cmake uuid-dev libgcrypt-dev ca-certificates \
 scsitools mg htop module-assistant debhelper runit parted \
 cloud-guest-utils anacron software-properties-common \
 xfsprogs gdisk libpam-cracklib chrony dbus nvme-cli rng-tools fdisk \
-ethtool"
+ethtool \
+nftables"
 
 debs="$debs gpg-agent libcurl4 libcurl4-openssl-dev resolvconf net-tools ifupdown"
 


### PR DESCRIPTION
This will be helpful for troubleshooting
now that we use nftables intead of iptables
for NATs and monit firewall rules

Output on an existing stemcell:
```
# apt-get install nftables
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  libjansson4 libnftables1
Suggested packages:
  firewalld
The following NEW packages will be installed:
  libjansson4 libnftables1 nftables
0 upgraded, 3 newly installed, 0 to remove and 40 not upgraded.
Need to get 432 kB of archives.
After this operation, 1,209 kB of additional disk space will be used.
Do you want to continue? [Y/n]
```