### PR TITLE
Add Rosetta x86_64 emulation compatibility for warden stemcells

### DIFF
--- a/bosh-stemcell/spec/stemcells/warden_spec.rb
+++ b/bosh-stemcell/spec/stemcells/warden_spec.rb
@@ -21,4 +21,32 @@ describe 'Warden Stemcell', stemcell_image: true do
     end
   end
 
+  context 'Rosetta x86_64 emulation compatibility for Apple Silicon' do
+    # These systemd drop-in overrides disable security features that conflict
+    # with Rosetta's JIT compilation on Apple Silicon Macs
+
+    rosetta_services = %w[
+      systemd-journald
+      systemd-resolved
+      systemd-networkd
+      systemd-logind
+      systemd-timesyncd
+      auditd
+    ]
+
+    rosetta_services.each do |service|
+      describe file("/etc/systemd/system/#{service}.service.d/rosetta-compat.conf") do
+        it { should be_file }
+        its(:content) { should include('MemoryDenyWriteExecute=no') }
+        its(:content) { should include('LockPersonality=no') }
+        its(:content) { should include('NoNewPrivileges=no') }
+      end
+    end
+
+    describe file('/etc/systemd/system/systemd-binfmt.service') do
+      it { should be_symlink }
+      it { should be_linked_to '/dev/null' }
+    end
+  end
+
 end

--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -47,3 +47,31 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
   }
 }
 JSON
+
+# Rosetta x86_64 emulation compatibility for Apple Silicon Macs
+#
+# When running warden stemcells under Rosetta emulation on Apple Silicon,
+# several systemd services fail because their security hardening features
+# (MemoryDenyWriteExecute, SystemCallFilter, etc.) conflict with Rosetta's
+# JIT compilation which requires writable+executable memory.
+#
+# We create systemd drop-in overrides to disable these security features.
+# This is acceptable for warden stemcells since they run in containerized
+# environments where the host provides security isolation.
+
+rosetta_services=(
+  systemd-journald
+  systemd-resolved
+  systemd-networkd
+  systemd-logind
+  systemd-timesyncd
+  auditd
+)
+
+for service in "${rosetta_services[@]}"; do
+  mkdir -p "$chroot/etc/systemd/system/${service}.service.d"
+  cp "$assets_dir/rosetta-compat.conf" "$chroot/etc/systemd/system/${service}.service.d/rosetta-compat.conf"
+done
+
+# Mask systemd-binfmt.service which fails under Rosetta emulation
+run_in_chroot "$chroot" "systemctl mask systemd-binfmt.service"

--- a/stemcell_builder/stages/base_warden/assets/rosetta-compat.conf
+++ b/stemcell_builder/stages/base_warden/assets/rosetta-compat.conf
@@ -1,0 +1,12 @@
+[Service]
+# Disable security features that conflict with Rosetta x86_64 emulation
+# on Apple Silicon Macs. Rosetta uses JIT compilation which requires
+# writable+executable memory.
+#
+# These overrides are safe for warden stemcells since they run in
+# containerized environments where the host provides security isolation.
+MemoryDenyWriteExecute=no
+SystemCallArchitectures=
+SystemCallFilter=
+LockPersonality=no
+NoNewPrivileges=no


### PR DESCRIPTION
## Summary

- Add systemd drop-in overrides to disable security features that conflict with Rosetta's JIT compilation on Apple Silicon Macs
- Mask `systemd-binfmt.service` which fails under Rosetta emulation
- Add tests to verify the Rosetta compatibility configurations

## Background

When running warden stemcells under Rosetta x86_64 emulation on Apple Silicon Macs, several systemd services fail because their security hardening features (`MemoryDenyWriteExecute`, `SystemCallFilter`, etc.) conflict with Rosetta's JIT compilation which requires writable+executable memory.

This change is based on the patches from [instant-bosh](https://github.com/rkoster/instant-bosh/blob/32c294a319522bbf633cb5f3092500df21aee6a1/apple-silicon/stemcell/Dockerfile), converted into proper stemcell builder fixes that only affect the warden stemcell.

## Changes

### New file: `stemcell_builder/stages/base_warden/assets/rosetta-compat.conf`

Systemd drop-in configuration that disables security features:
- `MemoryDenyWriteExecute=no`
- `SystemCallArchitectures=` (cleared)
- `SystemCallFilter=` (cleared)
- `LockPersonality=no`
- `NoNewPrivileges=no`

### Modified: `stemcell_builder/stages/base_warden/apply.sh`

Installs the drop-in configuration for the following services:
- `systemd-journald`
- `systemd-resolved`
- `systemd-networkd`
- `systemd-logind`
- `systemd-timesyncd`
- `auditd`

Also masks `systemd-binfmt.service`.

### Modified: `bosh-stemcell/spec/stemcells/warden_spec.rb`

Added tests to verify:
- Drop-in configuration files exist for all affected services
- Configuration contains expected directives
- `systemd-binfmt.service` is masked (symlinked to `/dev/null`)