### PR TITLE
Revert "Merge pull request #470 from rkoster/remove-monit-permit-access"

### DIFF
--- a/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -40,6 +40,7 @@ describe 'Azure Stemcell', stemcell_image: true do
       its(:content) { should include('"DevicePathResolutionType": "scsi"') }
       its(:content) { should include('"CreatePartitionIfNoEphemeralDisk": true') }
       its(:content) { should include('"PartitionerType": "parted"') }
+      its(:content) { should include('"UseMonitIptablesFirewall": true') }
     end
   end
 

--- a/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
@@ -354,6 +354,7 @@ HERE
     describe file('/var/vcap/bosh/agent.json') do
       it { should be_valid_json_file }
       its(:content) { should match('"Type": "HTTP"') }
+      its(:content) { should match('"UseMonitIptablesFirewall": true') }
     end
   end
 
@@ -371,6 +372,7 @@ HERE
     describe file('/var/vcap/bosh/agent.json') do
       it { should be_valid_json_file }
       its(:content) { should match('"Type": "HTTP"') }
+      its(:content) { should match('"UseMonitIptablesFirewall": true') }
     end
   end
 
@@ -388,6 +390,7 @@ HERE
     describe file('/var/vcap/bosh/agent.json') do
       it { should be_valid_json_file }
       its(:content) { should match('"Type": "InstanceMetadata"') }
+      its(:content) { should match('"UseMonitIptablesFirewall": true') }
     end
   end
 
@@ -407,6 +410,7 @@ HERE
       its(:content) { should match('"CreatePartitionIfNoEphemeralDisk": true') }
       its(:content) { should match('"Type": "ConfigDrive"') }
       its(:content) { should match('"Type": "HTTP"') }
+      its(:content) { should match('"UseMonitIptablesFirewall": true') }
     end
   end
 
@@ -424,6 +428,7 @@ HERE
     describe file('/var/vcap/bosh/agent.json') do
       it { should be_valid_json_file }
       its(:content) { should match('"Type": "CDROM"') }
+      its(:content) { should match('"UseMonitIptablesFirewall": true') }
     end
   end
 
@@ -443,6 +448,7 @@ HERE
       its(:content) { should match('"Type": "HTTP"') }
       its(:content) { should match('"UserDataPath": "/rest/v3.1/SoftLayer_Resource_Metadata/getUserMetadata.json"') }
       its(:content) { should match('"UseRegistry": true') }
+      its(:content) { should match('"UseMonitIptablesFirewall": true') }
     end
   end
 
@@ -460,6 +466,7 @@ HERE
       it { should be_valid_json_file }
       its(:content) { should match('"CreatePartitionIfNoEphemeralDisk": true') }
       its(:content) { should match('"Type": "HTTP"') }
+      its(:content) { should match('"UseMonitIptablesFirewall": true') }
     end
   end
 

--- a/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
@@ -10,7 +10,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
     "Linux": {
       $(get_partitioner_type_mapping)
       "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio"
+      "DevicePathResolutionType": "virtio",
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {

--- a/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
@@ -10,7 +10,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
     "Linux": {
       $(get_partitioner_type_mapping)
       "DevicePathResolutionType": "virtio",
-      "CreatePartitionIfNoEphemeralDisk": true
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {

--- a/stemcell_builder/stages/bosh_azure_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_agent_settings/apply.sh
@@ -10,7 +10,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
     "Linux": {
       "CreatePartitionIfNoEphemeralDisk": true,
       "DevicePathResolutionType": "scsi",
-      "PartitionerType": "parted"
+      "PartitionerType": "parted",
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
@@ -12,7 +12,8 @@ cat > $agent_settings_file <<JSON
     "Linux": {
       $(get_partitioner_type_mapping)
       "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio"
+      "DevicePathResolutionType": "virtio",
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {

--- a/stemcell_builder/stages/bosh_go_agent/apply.sh
+++ b/stemcell_builder/stages/bosh_go_agent/apply.sh
@@ -35,7 +35,6 @@ bosh_agent_version=$(cat ${assets_dir}/bosh-agent-version)
 /usr/bin/meta4 file-download --metalink=${assets_dir}/metalink.meta4 --file=bosh-agent-${bosh_agent_version}-linux-amd64 bosh-agent
 
 mv bosh-agent $chroot/var/vcap/bosh/bin/
-ln --force $chroot/var/vcap/bosh/bin/bosh-agent $chroot/usr/local/sbin/bosh-enable-monit-access
 
 cp $assets_dir/bosh-agent-rc $chroot/var/vcap/bosh/bin/bosh-agent-rc
 

--- a/stemcell_builder/stages/bosh_go_agent/assets/runit/agent/run
+++ b/stemcell_builder/stages/bosh_go_agent/assets/runit/agent/run
@@ -4,6 +4,10 @@ set -e
 export PATH=/var/vcap/bosh/bin:$PATH
 exec 2>&1
 
+source /var/vcap/bosh/etc/monit-access-helper.sh
+
+permit_monit_access
+
 cd /var/vcap/bosh
 
 exec nice -n -15 /var/vcap/bosh/bin/bosh-agent -P $(cat /var/vcap/bosh/etc/operating_system) -C /var/vcap/bosh/agent.json

--- a/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
@@ -11,7 +11,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
       "CreatePartitionIfNoEphemeralDisk": true,
       $(get_partitioner_type_mapping)
       "DevicePathResolutionType": "virtio",
-      "VirtioDevicePrefix": "google"
+      "VirtioDevicePrefix": "google",
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {

--- a/stemcell_builder/stages/bosh_monit/apply.sh
+++ b/stemcell_builder/stages/bosh_monit/apply.sh
@@ -30,4 +30,12 @@ chmod 0700 $chroot/$bosh_dir/etc/monitrc
 mkdir -p $chroot/$bosh_app_dir/monit
 touch $chroot/$bosh_app_dir/monit/empty.monitrc
 
+# Monit wrapper script:
+mv $chroot/$bosh_dir/bin/monit $chroot/$bosh_dir/bin/monit-actual
+
 cp $dir/assets/monit-access-helper.sh $chroot/$bosh_dir/etc/
+cp $dir/assets/monit $chroot/$bosh_dir/bin/monit
+chmod +x $chroot/$bosh_dir/bin/monit
+
+cp $dir/assets/restrict-monit-api-access $chroot/etc/network/if-up.d/restrict-monit-api-access
+chmod +x $chroot/etc/network/if-up.d/restrict-monit-api-access

--- a/stemcell_builder/stages/bosh_monit/assets/monit
+++ b/stemcell_builder/stages/bosh_monit/assets/monit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source /var/vcap/bosh/etc/monit-access-helper.sh
+
+permit_monit_access
+
+exec /var/vcap/bosh/bin/monit-actual "$@"

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -1,3 +1,24 @@
+# This is the integer value of the argument "0xb0540001", which is
+# b054:0001 . The major number (the left-hand side) is "BOSH", leet-ified.
+# The minor number (the right-hand side) is 1, indicating that this is the
+# first thing in our "BOSH" classid namespace.
+#
+# _Hopefully_ noone uses a major number of "b054", and we avoid collisions _forever_!
+# If you need to select new classids for firewall rules or traffic control rules, keep
+# the major number "b054" for bosh stuff, unless there's a good reason to not.
+#
+# The net_cls.classid structure is described in more detail here:
+# https://www.kernel.org/doc/Documentation/cgroup-v1/net_cls.txt
+
+monit_isolation_classid=2958295041
+
 permit_monit_access() {
-  /usr/local/sbin/bosh-enable-monit-access
+    net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk '{ print $2 }' )"
+    net_cls_subproc="$(grep net_cls /proc/self/cgroup | awk -F ":" '{ print $3 }' )"
+    monit_access_cgroup="${net_cls_location}/${net_cls_subproc}/monit-api-access"
+
+    mkdir -p "${monit_access_cgroup}"
+    echo "${monit_isolation_classid}" > "${monit_access_cgroup}/net_cls.classid"
+
+    echo $$ > "${monit_access_cgroup}/tasks"
 }

--- a/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
+++ b/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source /var/vcap/bosh/etc/monit-access-helper.sh
+
+if iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+	    -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
+then
+  /bin/true
+else
+    iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+	     -m cgroup \! --cgroup "${monit_isolation_classid}" -j DROP
+    iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+	     -m state --state ESTABLISHED,RELATED -j ACCEPT
+fi

--- a/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
@@ -12,7 +12,8 @@ cat > $agent_settings_file <<JSON
     "Linux": {
       $(get_partitioner_type_mapping)
       "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio"
+      "DevicePathResolutionType": "virtio",
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {

--- a/stemcell_builder/stages/bosh_softlayer_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_softlayer_agent_settings/apply.sh
@@ -12,7 +12,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
       $(get_partitioner_type_mapping)
       "CreatePartitionIfNoEphemeralDisk": true,
       "ScrubEphemeralDisk": true,
-      "DevicePathResolutionType": "iscsi"
+      "DevicePathResolutionType": "iscsi",
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {

--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
@@ -9,7 +9,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
   "Platform": {
     "Linux": {
       $(get_partitioner_type_mapping)
-      "DevicePathResolutionType": "scsi"
+      "DevicePathResolutionType": "scsi",
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {


### PR DESCRIPTION
This is actually a breaking change in the stemcell contract, and we found some releases were relying on the previous behavior.  Our intention is to restore this behavior in jammy, and teach the bosh agent to _not_ apply it's nftables rules on jammy.

On noble, the changes made recently remain the same - the bosh agent will be responsible for restricting monit access.