### PR TITLE
Harden sudo file ownership in stemcell build (noble)

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -29,6 +29,18 @@ shared_examples_for 'every OS image' do
     end
   end
 
+  context 'sudo configuration files must be owned by root' do
+    describe file('/etc/sudo.conf') do
+      it { should be_owned_by('root') }
+      its(:group) { should eq('root') }
+    end
+
+    describe file('/usr/libexec/sudo/sudoers.so') do
+      it { should be_owned_by('root') }
+      its(:group) { should eq('root') }
+    end
+  end
+
   context 'effective GID for UID vcap' do
     describe command("id -gn vcap") do
       its (:stdout) { should eq "vcap\n" }

--- a/stemcell_builder/stages/base_file_permission/apply.sh
+++ b/stemcell_builder/stages/base_file_permission/apply.sh
@@ -12,4 +12,7 @@ chown root:root $chroot/etc/gshadow
 chmod 0000 $chroot/etc/shadow
 chown root:root $chroot/etc/shadow
 
+chown root:root $chroot/etc/sudo.conf
+chown -R root:root $chroot/usr/libexec/sudo/
+
 restrict_binary_setuid


### PR DESCRIPTION
Same as https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/492


## Summary

- Adds explicit `chown root:root` for `/etc/sudo.conf` and `/usr/libexec/sudo/` in the
  `base_file_permission` build stage to ensure sudo files are always owned by root
- Adds spec tests in the `every OS image` shared examples to verify ownership of
  `/etc/sudo.conf` and `/usr/libexec/sudo/sudoers.so`

## Context

After upgrading Concourse workers from Ubuntu Jammy to Noble, heavy stemcell deploys on
AWS began failing with:
```
sudo: /etc/sudo.conf is owned by uid 65534, should be 0
sudo: /usr/libexec/sudo/sudoers.so must be owned by uid 0
sudo: fatal error, unable to load plugins
```


Ubuntu 24.04 enables `kernel.apparmor_restrict_unprivileged_userns=1` by default, which
restricts capabilities within unprivileged user namespaces. This causes unmapped UIDs to
fall back to 65534 (nobody) during the stemcell build, corrupting ownership of files that
were not explicitly chowned.

The primary fix is disabling the restriction on the workers (see https://github.com/cloudfoundry/concourse-infra-for-fiwg/pull/96 for the worker fix)
