### PR TITLE
 Add UseMonitIptablesFirewall to ubuntu-jammy agent cfg for warden stemcells

### DIFF
--- a/bosh-stemcell/spec/stemcells/warden_spec.rb
+++ b/bosh-stemcell/spec/stemcells/warden_spec.rb
@@ -45,4 +45,17 @@ describe 'Warden Stemcell', stemcell_image: true do
       it { should be_linked_to '/etc/sv/cron' }
     end
   end
+
+  context 'BOSH Agent configuration' do
+    describe file('/var/vcap/bosh/agent.json') do
+      it { should be_valid_json_file }
+      its(:content) { should include('"Type": "File"') }
+      its(:content) { should include('"SettingsPath": "/var/vcap/bosh/warden-cpi-agent-env.json"') }
+      its(:content) { should include('"UseDefaultTmpDir": true') }
+      its(:content) { should include('"UsePreformattedPersistentDisk": true') }
+      its(:content) { should include('"BindMountPersistentDisk": true') }
+      its(:content) { should include('"SkipDiskSetup": true') }
+      its(:content) { should include('"UseMonitIptablesFirewall": true') }
+    end
+  end
 end

--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -66,7 +66,8 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
       "UseDefaultTmpDir": true,
       "UsePreformattedPersistentDisk": true,
       "BindMountPersistentDisk": true,
-      "SkipDiskSetup": true
+      "SkipDiskSetup": true,
+      "UseMonitIptablesFirewall": true
     }
   },
   "Infrastructure": {


### PR DESCRIPTION
Without the `UseMonitIptablesFirewall` option set, bosh-agent will configure nftables based monit firewall rules that will interfere with monit access on ubuntu-jammy stemcells.

This commit restores cgroup-v1 based firewall behavior for warden stemcells.

ai-assisted=no