### PR TITLE
Enable stemcell builds on apple silicon (jammy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,32 @@ git clone git@github.com:cloudfoundry/bosh-linux-stemcell-builder.git
 cd bosh-linux-stemcell-builder
 git checkout ubuntu-jammy/master
 mkdir -p tmp
+docker build \
+   --platform linux/amd64 \
+   --build-arg SYFT_VERSION=v1.42.3 \
+   -t bosh/os-image-stemcell-builder:jammy \
+   ci/docker/os-image-stemcell-builder/
 docker run \
+   --platform linux/amd64 \
    --privileged \
    -v "$(pwd):/opt/bosh" \
    --workdir /opt/bosh \
    --user=1000:1000 \
    -it \
    bosh/os-image-stemcell-builder:jammy
-# You're now in the the Docker container
+# You're now in the Docker container
 gem install bundler
-bundle
+bundle install
  # build OS image
-bundle exec rake stemcell:build_os_image[ubuntu,jammy,$PWD/tmp/ubuntu_base_image.tgz] # build OS image
+bundle exec rake stemcell:build_os_image[ubuntu,jammy,$PWD/tmp/ubuntu_base_image.tgz]
  # build vSphere stemcell
 bundle exec rake stemcell:build_with_local_os_image[vsphere,esxi,ubuntu,jammy,$PWD/tmp/ubuntu_base_image.tgz]
 ```
 
 When building a vSphere stemcell, you must download `VMware-ovftool-*.bundle`
-and place it in the `ci/docker/os-image-stemcell-builder-jammy/` directory. See
-[External Assets](#external-assets) for download instructions.
+and place it in the `ci/docker/os-image-stemcell-builder/` directory before
+running `docker build`. See [External Assets](#external-assets) for download
+instructions.
 
 ### OS image
 
@@ -206,22 +213,26 @@ If you find yourself debugging any of the above processes, here is what you need
 The ovftool installer from VMWare can be found at
 [my.vmware.com](https://my.vmware.com/group/vmware/details?downloadGroup=OVFTOOL410&productId=489).
 
-The ovftool installer must be copied into the [ci/docker/os-image-stemcell-builder-jammy](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/tree/master/ci/docker/os-image-stemcell-builder) next to the Dockerfile or you will receive the error
+The ovftool installer must be copied into [ci/docker/os-image-stemcell-builder/](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/tree/master/ci/docker/os-image-stemcell-builder) next to the Dockerfile before building the Docker image, or you will receive an error like:
 
-    Step 24/30 : ADD ${OVF_TOOL_INSTALLER} /tmp/ovftool_installer.bundle
-    ADD failed: stat /var/lib/docker/tmp/docker-builder389354746/VMware-ovftool-4.1.0-2459827-lin.x86_64.bundle: no such file or directory
+```
+ADD failed: failed to compute cache key: "/VMware-ovftool-4.4.3-18663434-lin.x86_64.bundle": not found
+```
 
 ## Rebuilding the Docker Image
 
 The Docker image is published to
 [`bosh/os-image-stemcell-builder`](https://hub.docker.com/r/bosh/os-image-stemcell-builder/).
-You will need the ovftool installer present on your filesystem.
+You will need the ovftool installer present in
+`ci/docker/os-image-stemcell-builder/`.
 
-Rebuild the container with the `build` script...
+Rebuild the container with:
 
-    ./build os-image-stemcell-builder
+```bash
+docker build \
+   --platform linux/amd64 \
+   --build-arg SYFT_VERSION=v1.42.3 \
+   -t bosh/os-image-stemcell-builder:jammy \
+   ci/docker/os-image-stemcell-builder/
+```
 
-When ready, `push` to DockerHub and use the credentials from LastPass...
-
-    cd os-image-stemcell-builder
-    ./push

--- a/ci/docker/os-image-stemcell-builder/Dockerfile
+++ b/ci/docker/os-image-stemcell-builder/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     debootstrap \
     dnsutils \
     dosfstools \
+    fdisk \
     git \
     golang \
     jq \

--- a/stemcell_builder/stages/image_create_efi/apply.sh
+++ b/stemcell_builder/stages/image_create_efi/apply.sh
@@ -5,12 +5,6 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-# Install sfdisk if not available - it works better than parted on Docker Desktop for Apple Silicon
-if ! which sfdisk > /dev/null 2>&1; then
-  echo "Installing fdisk package (provides sfdisk)..."
-  apt-get update -qq && apt-get install -y -qq fdisk
-fi
-
 disk_image=${work}/${stemcell_image_name}
 
 # image_create_disk_size is in MiB

--- a/stemcell_builder/stages/image_create_efi/apply.sh
+++ b/stemcell_builder/stages/image_create_efi/apply.sh
@@ -5,14 +5,31 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
+# Install sfdisk if not available - it works better than parted on Docker Desktop for Apple Silicon
+if ! which sfdisk > /dev/null 2>&1; then
+  echo "Installing fdisk package (provides sfdisk)..."
+  apt-get update -qq && apt-get install -y -qq fdisk
+fi
+
 disk_image=${work}/${stemcell_image_name}
 
 # image_create_disk_size is in MiB
 dd if=/dev/null of=${disk_image} bs=1M seek=${image_create_disk_size} 2> /dev/null
-parted --script ${disk_image} mklabel msdos
-parted --script ${disk_image} mkpart primary fat32 0% 49MiB
-parted --script ${disk_image} set 1 esp on
-parted --script ${disk_image} mkpart primary ext2 50MiB 100%
+
+# Partition the disk image using sfdisk
+# sfdisk works better than parted in virtualized environments (Docker Desktop on Apple Silicon)
+# Partition layout:
+#   - Partition 1: EFI System Partition (ESP), ~49MiB, type EF (EFI)
+#   - Partition 2: Linux root partition, remaining space, type 83 (Linux)
+sfdisk ${disk_image} <<EOF
+label: dos
+unit: sectors
+
+# First partition: EFI (starts at 2048 sectors = 1MiB, size ~48MiB = 98304 sectors)
+start=2048, size=98304, type=ef, bootable
+# Second partition: Linux root (starts after EFI partition, uses remaining space)
+start=100352, type=83
+EOF
 
 # unmap the loop device in case it's already mapped
 timeout 100 bash -c "

--- a/stemcell_builder/stages/image_create_efi/config.sh
+++ b/stemcell_builder/stages/image_create_efi/config.sh
@@ -5,8 +5,7 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_config.bash
 
-# sfdisk will be installed at runtime if not available (see apply.sh)
-# kpartx is required for partition mapping
+assert_available sfdisk
 assert_available kpartx
 
 if [ -z "${image_create_disk_size:-}" ]

--- a/stemcell_builder/stages/image_create_efi/config.sh
+++ b/stemcell_builder/stages/image_create_efi/config.sh
@@ -5,7 +5,8 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_config.bash
 
-assert_available parted
+# sfdisk will be installed at runtime if not available (see apply.sh)
+# kpartx is required for partition mapping
 assert_available kpartx
 
 if [ -z "${image_create_disk_size:-}" ]


### PR DESCRIPTION
Use sfdisk instead of parted for disk partitioning. sfdisk causes fewer issues with virutalization, and appears to work reliably with docker desktop running on an m-series mac.