### PR TITLE
Remove redundant be_symlink assertion

### DIFF
--- a/bosh-stemcell/spec/stemcells/warden_spec.rb
+++ b/bosh-stemcell/spec/stemcells/warden_spec.rb
@@ -44,7 +44,6 @@ describe 'Warden Stemcell', stemcell_image: true do
     end
 
     describe file('/etc/systemd/system/systemd-binfmt.service') do
-      it { should be_symlink }
       it { should be_linked_to '/dev/null' }
     end
   end


### PR DESCRIPTION
Remove redundant be_symlink assertion in warden stemcell spec since be_linked_to already asserts the symlink target and ShelloutTypes::File does not implement #symlink?. This avoids calling a missing predicate and fixes CI failures.\n\nIf we prefer the more explicit assertion, we can instead implement ShelloutTypes::File#symlink? in a follow-up change.