### PR TITLE
Prevent systemd-binfmt from running in containers (Jammy)

### DIFF
--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -82,3 +82,6 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
   }
 }
 JSON
+
+# Mask systemd-binfmt.service which fails under Rosetta emulation
+run_in_chroot "$chroot" "systemctl mask systemd-binfmt.service"


### PR DESCRIPTION
This supersedes #473 and instead uses the approach that was merged in #486 for noble to keep the branches consistent. 