### PR TITLE
Enable building stemcells on apple silicon with vz/rosetta (Jammy)

### DIFF
--- a/bosh-stemcell/lib/shellout_types/chroot.rb
+++ b/bosh-stemcell/lib/shellout_types/chroot.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'shellwords'
 
 module ShelloutTypes
   class Chroot
@@ -8,6 +9,12 @@ module ShelloutTypes
       @@chroot_dir = dir
     end
 
+    def self.unmount_proc
+      dir = @@chroot_dir
+      return if dir.empty?
+      system('sudo', 'umount', "#{dir}/proc", [:out, :err] => '/dev/null')
+    end
+
     def initialize(dir = nil)
       @chroot_dir = dir unless dir.nil?
     end
@@ -15,9 +22,15 @@ module ShelloutTypes
     def run(*cmd)
       cmd.unshift('mknod -m 666 /dev/urandom c 1 9 2>/dev/null;')
       cmd.unshift('mknod -m 666 /dev/random c 1 8 2>/dev/null;')
-      stdout, stderr, status = Open3.capture3(
-        'sudo', 'chroot', chroot_dir, '/bin/bash', '-c', cmd.join(' ')
-      )
+      inner = cmd.join(' ')
+      wrapper = <<~SH.strip
+        if ! mountpoint -q #{chroot_dir}/proc 2>/dev/null; then
+          mkdir -p #{chroot_dir}/proc
+          mount -t proc proc #{chroot_dir}/proc
+        fi
+        chroot #{chroot_dir} /bin/bash -c #{inner.shellescape}
+      SH
+      stdout, stderr, status = Open3.capture3('sudo', '/bin/bash', '-c', wrapper)
       [stdout, stderr, status.exitstatus]
     end
 

--- a/bosh-stemcell/spec/shellout_types/spec_helper.rb
+++ b/bosh-stemcell/spec/shellout_types/spec_helper.rb
@@ -23,6 +23,7 @@ RSpec.configure do |config|
       end
 
       config.after(:suite) do
+        ShelloutTypes::Chroot.unmount_proc
         Bosh::Core::Shell.new.run("sudo rm -rf #{config.os_image_dir}")
       end
     elsif ENV['SHELLOUT_CHROOT_DIR']

--- a/bosh-stemcell/spec/support/os_image.rb
+++ b/bosh-stemcell/spec/support/os_image.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
         Bosh::Core::Shell.new.run("sudo tar xf #{ENV['OS_IMAGE']} -C #{config.os_image_dir}")
       end
       config.after(:suite) do
+        ShelloutTypes::Chroot.unmount_proc
         Bosh::Core::Shell.new.run("sudo rm -rf #{config.os_image_dir}")
       end
     else

--- a/bosh-stemcell/spec/support/stemcell_image.rb
+++ b/bosh-stemcell/spec/support/stemcell_image.rb
@@ -26,6 +26,7 @@ RSpec.configure do |config|
           ShelloutTypes::Chroot.chroot_dir = image_mount_point
         end
         config.after(:suite) do |example|
+          ShelloutTypes::Chroot.unmount_proc
           shell.run("sudo umount #{image_mount_point}/boot", output_command: verbose)
           shell.run("sudo umount #{image_mount_point}", output_command: verbose)
         end
@@ -37,6 +38,7 @@ RSpec.configure do |config|
           ShelloutTypes::Chroot.chroot_dir = disk_image.image_mount_point
         end
         config.after(:suite) do |example|
+          ShelloutTypes::Chroot.unmount_proc
           disk_image.unmount
         end
       end

--- a/stemcell_builder/stages/base_debootstrap/apply.sh
+++ b/stemcell_builder/stages/base_debootstrap/apply.sh
@@ -12,7 +12,74 @@ source "$base_dir/lib/prelude_apply.bash"
 
 # Bootstrap the base system
 echo "Running debootstrap"
+
+# Clean up any leftover state from previous failed runs. When debootstrap fails
+# it tries to rm -rf the chroot, but if /proc is mounted it cannot remove the
+# proc virtual files, leaving a partially populated directory that would trip up
+# a subsequent run.
+for _mnt in proc sys dev/pts dev; do
+  umount -l "$chroot/$_mnt" 2>/dev/null || true
+done
+rm -rf "$chroot"
+mkdir -p "$chroot"
+
+# Detect Rosetta x86_64 translation (Apple Silicon host running amd64 container).
+_rosetta=false
+if grep -q '/rosetta' /proc/self/maps 2>/dev/null; then
+  _rosetta=true
+fi
+
+# Work around Rosetta 2 / Apple Silicon compatibility issues with debootstrap.
+#
+# When building inside a Docker container on an ARM64 host with Rosetta x86_64
+# translation, debootstrap hits two problems:
+#
+#   1. detect_container() sees /.dockerenv and sets CONTAINER=docker, which
+#      triggers setup_proc_symlink during first_stage_install.  That function
+#      does `rm -rf $TARGET/proc; ln -s /proc $TARGET/proc`, creating a
+#      circular symlink that causes ELOOP when Rosetta reads /proc/self/exe.
+#
+#   2. setup_proc() during second_stage_install unmounts $TARGET/proc and then
+#      runs `in_target mount -t proc proc /proc`.  That executes the x86_64
+#      mount binary through Rosetta, which needs /proc/self/exe — but /proc
+#      was just unmounted.
+#
+# Fix — no debootstrap patching required:
+#
+#   (a) Temporarily hide /.dockerenv so detect_container() does not set
+#       CONTAINER=docker.  This prevents setup_proc_symlink entirely.
+#
+#   (b) Mount proc in the chroot *twice*: once as a real procfs, then a bind
+#       mount on top.  When setup_proc()'s `umount` runs, it peels the bind
+#       layer off but the underlying procfs survives, keeping /proc/self/exe
+#       available for Rosetta throughout the entire second stage.
+_dockerenv_hidden=false
+if [ "$_rosetta" = true ]; then
+  if [ -e /.dockerenv ]; then
+    mv /.dockerenv /.dockerenv.hidden
+    _dockerenv_hidden=true
+  fi
+
+  mkdir -p "$chroot/proc"
+  mount -t proc proc "$chroot/proc"
+  mount --bind "$chroot/proc" "$chroot/proc"
+fi
+
+cleanup_debootstrap() {
+  if [ "$_rosetta" = true ]; then
+    umount "$chroot/proc" 2>/dev/null || true
+    umount "$chroot/proc" 2>/dev/null || true
+  fi
+  if [ "$_dockerenv_hidden" = true ]; then
+    mv /.dockerenv.hidden /.dockerenv 2>/dev/null || true
+  fi
+}
+trap cleanup_debootstrap EXIT
+
 debootstrap --arch="$base_debootstrap_arch" "$base_debootstrap_suite" "$chroot" ""
+
+cleanup_debootstrap
+trap - EXIT
 
 # See https://bugs.launchpad.net/ubuntu/+source/update-manager/+bug/24061
 rm -f "$chroot"/var/lib/apt/lists/{archive,security,lock}*


### PR DESCRIPTION
## Enable building Jammy stemcells on Apple Silicon (Colima vz/Rosetta)

### Problem

Rosetta 2 requires `/proc/self/exe` to translate x86_64 binaries. The build breaks this in two places:

1. **`debootstrap`** detects `/.dockerenv`, sets `CONTAINER=docker`, and replaces `$TARGET/proc` with a symlink that causes `ELOOP`. It also unmounts `/proc` mid-build, then tries to remount it with an x86_64 binary that needs the `/proc` it just removed.

2. **rspec test harness** (`Chroot#run`) unmounts `/proc` after every command. The next command's remount check is itself an x86_64 binary that needs `/proc` — chicken-and-egg.

### Fix

**`base_debootstrap/apply.sh`** — Conditional on Rosetta detection (`/proc/self/maps`), no debootstrap patching:
- Hide `/.dockerenv` to prevent `setup_proc_symlink`
- Double-mount proc (real + bind) so debootstrap's `umount` peels one layer but the underlying mount survives

**`chroot.rb`** — Mount `/proc` once on first use, never unmount between commands. Added `Chroot.unmount_proc` class method called from each test path's `after(:suite)` for cleanup.

### Scope

On native x86_64 the Rosetta detection is never triggered and behavior is unchanged.
