### PR TITLE
Warden-specific stage to clean up all custom/optional systemd services

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -202,6 +202,7 @@ module Bosh::Stemcell
       [
         :system_parameters,
         :base_warden,
+        :base_systemd_clean,
         :bosh_clean,
         :bosh_harden,
         :bosh_clean_ssh,

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -309,6 +309,7 @@ module Bosh::Stemcell
           [
             :system_parameters,
             :base_warden,
+            :base_systemd_clean,
             :bosh_clean,
             :bosh_harden,
             :bosh_clean_ssh,

--- a/stemcell_builder/stages/base_systemd_clean/apply.sh
+++ b/stemcell_builder/stages/base_systemd_clean/apply.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/lib/prelude_bosh.bash
+
+# only load minimal set of systemd units / services
+# https://github.com/asg1612/docker-systemd/blob/master/Dockerfile
+run_in_chroot "${chroot}" "
+if [ -d /run/systemd/system ]; then
+  find /etc/systemd/system /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*firstboot*' \
+    -not -name '*bosh-agent*' \
+    -not -name '*dbus*' \
+    -not -name '*journald*' \
+    -not -name '*logrotate*' \
+    -not -name '*runit*' \
+    -not -name '*ssh*' \
+    -not -name '*systemd-user-sessions*' \
+    -not -name '*systemd-tmpfiles*' \
+    -exec rm -f {} \\;
+fi
+"


### PR DESCRIPTION
These changes are related to issues:
- [warden/boshlite: Missing SSH keys in /etc/ssh causing issues with ssh](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/504)
- [Necessary systemd services could be removed during hardening](https://github.com/cloudfoundry/bosh-docker-cpi-release/issues/58)

Added a new stage `base_systemd_clean` to the `warden_stages` collection, which is applied during stemcell build, and removes all custom and optional systemd services, keeping only the necessary minimum set.