### PR TITLE
Allow building a stemcell with a custom agent (jammy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The arguments to `stemcell:build_with_local_os_image` are:
    of the most recent release and add one, e.g.: "0.0.7" → "0.0.8". If not
    specified, it will default to "0000".
 
+While building a stemcell for development purposes it is possible to set the BOSH_AGENT_BIN_PATH environment variable to inject an agent binary into the stemcell instead of downloading one.
+
 ### The Resulting Stemcell
 
 You can find the resulting stemcell in the `tmp/` directory of the host, or in

--- a/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
@@ -100,7 +100,10 @@ module Bosh::Stemcell
     end
 
     def command_env
-      "env #{hash_as_bash_env(proxy_settings_from_environment.merge(build_time_settings))}"
+      settings = proxy_settings_from_environment
+        .merge(build_time_settings)
+        .merge(passthrough_settings_from_environment)
+      "env #{hash_as_bash_env(settings)}"
     end
 
     private
@@ -228,6 +231,12 @@ module Bosh::Stemcell
 
     def proxy_settings_from_environment
       keep = %w(HTTP_PROXY HTTPS_PROXY NO_PROXY)
+
+      environment.select { |k| keep.include?(k.upcase) }
+    end
+
+    def passthrough_settings_from_environment
+      keep = %w(BOSH_AGENT_BIN_PATH)
 
       environment.select { |k| keep.include?(k.upcase) }
     end

--- a/stemcell_builder/stages/bosh_go_agent/apply.sh
+++ b/stemcell_builder/stages/bosh_go_agent/apply.sh
@@ -23,6 +23,15 @@ rm -f /etc/service/monit
 ln -s /etc/sv/monit /etc/service/monit
 "
 
+# Resolve BOSH_AGENT_BIN_PATH to absolute before cd changes the working directory
+if [[ -n "${BOSH_AGENT_BIN_PATH:-}" ]]; then
+  BOSH_AGENT_BIN_PATH=$(readlink -f "${BOSH_AGENT_BIN_PATH}")
+  if [[ ! -f "${BOSH_AGENT_BIN_PATH}" ]]; then
+    echo "Error: BOSH_AGENT_BIN_PATH '${BOSH_AGENT_BIN_PATH}' does not exist or is not a regular file" >&2
+    exit 1
+  fi
+fi
+
 # Alerts for monit config
 cp -a $assets_dir/alerts.monitrc $chroot/var/vcap/monit/alerts.monitrc
 cd $assets_dir
@@ -31,8 +40,13 @@ wget -O /usr/bin/meta4 https://github.com/dpb587/metalink/releases/download/v0.2
   && echo "81a592eaf647358563f296aced845ac60d9061a45b30b852d1c3f3674720fe19  /usr/bin/meta4" | shasum -a 256 -c \
   && chmod +x /usr/bin/meta4
 
-bosh_agent_version=$(cat ${assets_dir}/bosh-agent-version)
-/usr/bin/meta4 file-download --metalink=${assets_dir}/metalink.meta4 --file=bosh-agent-${bosh_agent_version}-linux-amd64 bosh-agent
+if [[ -n "${BOSH_AGENT_BIN_PATH:-}" ]]; then
+  echo "BOSH_AGENT_BIN_PATH is set — using custom bosh-agent binary from: ${BOSH_AGENT_BIN_PATH}"
+  cp "${BOSH_AGENT_BIN_PATH}" bosh-agent
+else
+  bosh_agent_version=$(cat "${assets_dir}/bosh-agent-version")
+  /usr/bin/meta4 file-download --metalink="${assets_dir}/metalink.meta4" --file="bosh-agent-${bosh_agent_version}-linux-amd64" bosh-agent
+fi
 
 mv bosh-agent $chroot/var/vcap/bosh/bin/
 


### PR DESCRIPTION
Set BOSH_AGENT_BIN_PATH=./bosh-agent to provide a bosh agent binary to be injected into the stemcell being built. Useful when doing agent development work.

I don't love environment variables, but since this is only a development flow it doesn't seem like it makes much sense as a rake task argument. 