### PR TITLE
[Noble] Fix "bundle install" permission error in os-image-stemcell-builder Docker image

### DIFF
--- a/ci/docker/os-image-stemcell-builder/Dockerfile
+++ b/ci/docker/os-image-stemcell-builder/Dockerfile
@@ -91,6 +91,11 @@ RUN meta4_cli_path="/usr/local/bin/meta4" \
       > "${meta4_cli_path}" \
     && chmod +x "${meta4_cli_path}"
 
+ENV GEM_HOME="${GEM_HOME}" \
+    BUNDLE_APP_CONFIG="${GEM_HOME}" \
+    BUNDLE_SILENCE_ROOT_WARNING=1
+ENV PATH="${GEM_HOME}/bin:${PATH}"
+
 RUN cd /tmp  \
     && curl --show-error -sL "${RUBY_INSTALL_URL}" \
       | tar -xzf - \
@@ -103,9 +108,8 @@ RUN cd /tmp  \
     && ruby-install --jobs=${NUM_CPUS} --cleanup --system ruby ${RUBY_VERSION} \
       -- --disable-install-doc --disable-install-rdoc \
     && gem update --system \
-    && bundle config --global path "${GEM_HOME}" \
-    && bundle config --global bin "${GEM_HOME}/bin"
-ENV PATH=${GEM_HOME}/bin:${PATH}
+    && mkdir -p "${GEM_HOME}/bin" \
+    && chown -R ubuntu:ubuntu "${GEM_HOME}"
 
 RUN syft_cli_path="/usr/local/bin/syft" \
     && curl --show-error -sL "${SYFT_CLI_URL}" \


### PR DESCRIPTION
The `build-os-image` job fails for the `ubuntu-noble` pipelines with:

```
Bundler::PermissionError: There was an error while trying to create
`/usr/local/lib/ruby/gems/3.2.0/gems/rake-13.0.3`.
```

`bundle install --local` runs as user `ubuntu` but tries to write to the system gem directory, which is owned by root.

https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-noble-builder/jobs/build-os-image/builds/625


### Fix

Replace `bundle config --global` with `ENV` vars, following the [official Ruby Docker image pattern](https://github.com/docker-library/ruby):

- `GEM_HOME` — tells RubyGems where to install gems
- `BUNDLE_APP_CONFIG` — tells Bundler to read config from `$GEM_HOME` instead of per-user paths
- `BUNDLE_SILENCE_ROOT_WARNING` — suppresses the root user warning

The `GEM_HOME` directory is created and owned by `ubuntu:ubuntu` so the build user can write to it.
