### PR TITLE
[Jammy] Fix "bundle install" permission error in os-image-stemcell-builder Docker image

### DIFF
--- a/ci/docker/os-image-stemcell-builder/Dockerfile
+++ b/ci/docker/os-image-stemcell-builder/Dockerfile
@@ -96,6 +96,11 @@ RUN meta4_cli_path="/usr/local/bin/meta4" \
       > "${meta4_cli_path}" \
     && chmod +x "${meta4_cli_path}"
 
+ENV GEM_HOME="${GEM_HOME}" \
+    BUNDLE_APP_CONFIG="${GEM_HOME}" \
+    BUNDLE_SILENCE_ROOT_WARNING=1
+ENV PATH="${GEM_HOME}/bin:${PATH}"
+
 RUN cd /tmp  \
     && curl --show-error -sL "${RUBY_INSTALL_URL}" \
       | tar -xzf - \
@@ -108,9 +113,8 @@ RUN cd /tmp  \
     && ruby-install --jobs=${NUM_CPUS} --cleanup --system ruby ${RUBY_VERSION} \
       -- --disable-install-doc --disable-install-rdoc \
     && gem update --system \
-    && bundle config --global path "${GEM_HOME}" \
-    && bundle config --global bin "${GEM_HOME}/bin"
-ENV PATH=${GEM_HOME}/bin:${PATH}
+    && mkdir -p "${GEM_HOME}/bin" \
+    && chown -R ubuntu:ubuntu "${GEM_HOME}"
 
 RUN syft_cli_path="/usr/local/bin/syft" \
     && curl --show-error -sL "${SYFT_CLI_URL}" \

--- a/ci/tasks/os-images/build.sh
+++ b/ci/tasks/os-images/build.sh
@@ -33,6 +33,7 @@ fi
 sudo chown -R ubuntu .
 sudo chown -R ubuntu:ubuntu /mnt
 sudo chmod u+s "$(which sudo)"
+bundle install --local
 sudo --preserve-env --set-home --user ubuntu -- /bin/bash --login -i <<SUDO
 bundle exec rake stemcell:build_os_image[$OPERATING_SYSTEM_NAME,$OPERATING_SYSTEM_VERSION,$OS_IMAGE]
 SUDO

--- a/ci/tasks/os-images/build.sh
+++ b/ci/tasks/os-images/build.sh
@@ -34,6 +34,5 @@ sudo chown -R ubuntu .
 sudo chown -R ubuntu:ubuntu /mnt
 sudo chmod u+s "$(which sudo)"
 sudo --preserve-env --set-home --user ubuntu -- /bin/bash --login -i <<SUDO
-bundle install --local
 bundle exec rake stemcell:build_os_image[$OPERATING_SYSTEM_NAME,$OPERATING_SYSTEM_VERSION,$OS_IMAGE]
 SUDO


### PR DESCRIPTION
The `build-os-image` job fails for the `ubuntu-jammy` pipelines with:

```
Bundler::PermissionError: There was an error while trying to create
`/usr/local/lib/ruby/gems/3.2.0/gems/rake-13.0.3`.
```

`bundle install --local` runs as user `ubuntu` but tries to write to the system gem directory, which is owned by root.

https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-jammy-builder/jobs/build-os-image/builds/705


### Fix

Replace `bundle config --global` with `ENV` vars, following the [official Ruby Docker image pattern](https://github.com/docker-library/ruby):

- `GEM_HOME` — tells RubyGems where to install gems
- `BUNDLE_APP_CONFIG` — tells Bundler to read config from `$GEM_HOME` instead of per-user paths
- `BUNDLE_SILENCE_ROOT_WARNING` — suppresses the root user warning

The `GEM_HOME` directory is created and owned by `ubuntu:ubuntu` so the build user can write to it.
