### PR TITLE
Fix usn-log.json path in build-release-metadata.sh

### DIFF
--- a/ci/tasks/build-release-metadata.sh
+++ b/ci/tasks/build-release-metadata.sh
@@ -42,15 +42,15 @@ bosh_agent_version=$(cat "${REPO_PARENT}/bosh-linux-stemcell-builder/stemcell_bu
 
 if [[ "${OS_NAME}" == "ubuntu" ]]; then
   # Ensure URL for usn-log from metalink exists before attempting to download.
-  usn_log_json_file="${REPO_PARENT}/bosh-linux-stemcell-builder/${usn_log_json_file}/usn-log.json"
+  usn_log_json_file="${REPO_PARENT}/bosh-linux-stemcell-builder/usn-log.json"
   touch "${usn_log_json_file}"
   usn_metalink_path="${REPO_PARENT}/bosh-linux-stemcell-builder/bosh-stemcell/image-metalinks/${BRANCH}/${OS_NAME}-${OS_VERSION}.meta4"
-  if [[ -n "$(meta4 file-urls --metalink "${usn_metalink_path}" --file "${usn_log_json_file}")" ]]; then
+  if [[ -n "$(meta4 file-urls --metalink "${usn_metalink_path}" --file usn-log.json)" ]]; then
     meta4 file-download \
       --skip-hash-verification \
       --skip-signature-verification \
       --metalink "${usn_metalink_path}" \
-      --file "${usn_log_json_file}" \
+      --file usn-log.json \
       "${usn_log_json_file}"
   fi
 


### PR DESCRIPTION
Looks like this was a result of the change here - https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/509/changes/878080f77d1c7b725a90e1ec7a52cf9359d8eaff

`publish-ubuntu-jammy` pipeline is currently failing: https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-jammy-publisher/jobs/publish-ubuntu-jammy-1/builds/58

```bash
bosh-stemcells-ci/ci/tasks/build-release-metadata.sh: line 45: usn_log_json_file: unbound variable
```