### PR TITLE
CI: ensure that the correct resource is used when running tasks

### DIFF
--- a/ci/tasks/build-docker-args.sh
+++ b/ci/tasks/build-docker-args.sh
@@ -28,7 +28,7 @@ yq_cli_url="$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest 
 ruby_install_url="$(curl -s https://api.github.com/repos/postmodern/ruby-install/releases/latest \
                     | jq -r '.assets[] | select(.name | endswith ("tar.gz")) | .browser_download_url')"
 
-ruby_version="$(cat "${REPO_ROOT}/.ruby-version")"
+ruby_version="$(cat "${REPO_PARENT}/bosh-linux-stemcell-builder/.ruby-version")"
 gem_home="/usr/local/bundle"
 
 cat << EOF > "${REPO_PARENT}/docker-build-args/docker-build-args.json"

--- a/ci/tasks/build-release-metadata.sh
+++ b/ci/tasks/build-release-metadata.sh
@@ -36,7 +36,7 @@ pushd "${REPO_PARENT}/candidate-stemcell"
   kernel_version=$(grep "${KERNEL_PACKAGE}" packages.txt | awk '{print $3}')
 popd
 
-bosh_agent_version=$(cat "${REPO_ROOT}/stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-version")
+bosh_agent_version=$(cat "${REPO_PARENT}/bosh-linux-stemcell-builder/stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-version")
 {
   echo "## Metadata:"
   echo "**BOSH Agent Version**: ${bosh_agent_version}"
@@ -45,9 +45,9 @@ bosh_agent_version=$(cat "${REPO_ROOT}/stemcell_builder/stages/bosh_go_agent/ass
 
 if [[ "${OS_NAME}" == "ubuntu" ]]; then
   # Ensure URL for usn-log from metalink exists before attempting to download.
-  usn_log_json_file="${REPO_ROOT}/usn-log.json"
+  usn_log_json_file="${REPO_PARENT}/bosh-linux-stemcell-builder/usn-log.json"
   touch "${usn_log_json_file}"
-  usn_metalink_path="${REPO_ROOT}/bosh-stemcell/image-metalinks/${BRANCH}/${OS_NAME}-${OS_VERSION}.meta4"
+  usn_metalink_path="${REPO_PARENT}/bosh-linux-stemcell-builder/bosh-stemcell/image-metalinks/${BRANCH}/${OS_NAME}-${OS_VERSION}.meta4"
   if [[ -n "$(meta4 file-urls --metalink "${usn_metalink_path}" --file usn-log.json)" ]]; then
     meta4 file-download \
       --skip-hash-verification \

--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -71,7 +71,8 @@ for i in $(seq 0 64); do
   fi
 done
 
-chown -R ubuntu:ubuntu "${REPO_ROOT}"
+chown -R ubuntu:ubuntu "${REPO_ROOT}" # ci resource
+chown -R ubuntu:ubuntu "${REPO_PARENT}/bosh-linux-stemcell-builder"
 chown -R ubuntu:ubuntu /mnt
 
 OS_IMAGE=""
@@ -84,7 +85,7 @@ sudo chmod u+s "$(which sudo)"
 sudo --preserve-env --set-home --user ubuntu -- /bin/bash --login -i <<SUDO
 set -e
 
-cd "${REPO_ROOT}"
+cd "${REPO_PARENT}/bosh-linux-stemcell-builder"
 bundle install
 
 if [[ -z "$OS_IMAGE" ]]; then
@@ -107,7 +108,7 @@ mkdir -p "$( dirname "$meta4_path" )"
 rm -f "$meta4_path"
 meta4 create --metalink="$meta4_path"
 
-raw_images=( "${REPO_ROOT}/tmp"/*-raw.tgz )
+raw_images=( "${REPO_PARENT}/bosh-linux-stemcell-builder/tmp"/*-raw.tgz )
 if [ "${#raw_images[@]}" -ge 2 ]; then
   echo "Found more than one raw image: '${raw_images[*]}'" >&2
   exit 1
@@ -116,14 +117,14 @@ fi
 if [ -e "${raw_images[0]}" ] ; then
   # openstack currently publishes raw files
   raw_stemcell_filename="${stemcell_name}-raw.tgz"
-  mv "${REPO_ROOT}/tmp"/*-raw.tgz "${REPO_PARENT}/stemcell/${raw_stemcell_filename}"
+  mv "${REPO_PARENT}/bosh-linux-stemcell-builder/tmp"/*-raw.tgz "${REPO_PARENT}/stemcell/${raw_stemcell_filename}"
 
   meta4 import-file --metalink="$meta4_path" --version="${CANDIDATE_BUILD_NUMBER}" "${REPO_PARENT}/stemcell/${raw_stemcell_filename}"
   meta4 file-set-url --metalink="$meta4_path" --file="${raw_stemcell_filename}" "https://${S3_API_ENDPOINT}/${STEMCELL_BUCKET}/${IAAS}/${raw_stemcell_filename}"
 fi
 
 stemcell_filename="${stemcell_name}.tgz"
-mv "${REPO_ROOT}/tmp/${stemcell_filename}" "${REPO_PARENT}/stemcell/${stemcell_filename}"
+mv "${REPO_PARENT}/bosh-linux-stemcell-builder/tmp/${stemcell_filename}" "${REPO_PARENT}/stemcell/${stemcell_filename}"
 
 meta4 import-file --metalink="$meta4_path" --version="${CANDIDATE_BUILD_NUMBER}" "${REPO_PARENT}/stemcell/${stemcell_filename}"
 meta4 file-set-url --metalink="$meta4_path" --file="${stemcell_filename}" "https://${S3_API_ENDPOINT}/${STEMCELL_BUCKET}/${IAAS}/${stemcell_filename}"

--- a/ci/tasks/bump-bosh-agent.sh
+++ b/ci/tasks/bump-bosh-agent.sh
@@ -10,12 +10,15 @@ if [[ -n "${DEBUG:-}" ]]; then
   export BOSH_LOG_PATH="${BOSH_LOG_PATH:-${REPO_PARENT}/bosh-debug.log}"
 fi
 
-git clone "${REPO_ROOT}" "${REPO_PARENT}/bosh-linux-stemcell-builder-out"
+git clone "${REPO_PARENT}/bosh-linux-stemcell-builder" \
+  "${REPO_PARENT}/bosh-linux-stemcell-builder-out"
 
 version=$( cat "${REPO_PARENT}/bosh-agent/.resource/version" )
 
-cp "${REPO_PARENT}/bosh-agent/.resource/metalink.meta4" "${REPO_PARENT}/bosh-linux-stemcell-builder-out/stemcell_builder/stages/bosh_go_agent/assets/"
-cp "${REPO_PARENT}/bosh-agent/.resource/version" "${REPO_PARENT}/bosh-linux-stemcell-builder-out/stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-version"
+cp "${REPO_PARENT}/bosh-agent/.resource/metalink.meta4" \
+  "${REPO_PARENT}/bosh-linux-stemcell-builder-out/stemcell_builder/stages/bosh_go_agent/assets/"
+cp "${REPO_PARENT}/bosh-agent/.resource/version" \
+  "${REPO_PARENT}/bosh-linux-stemcell-builder-out/stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-version"
 
 pushd "${REPO_PARENT}/bosh-linux-stemcell-builder-out"
 	if [ "$(git status --porcelain)" != "" ]; then

--- a/ci/tasks/bump-bosh-blobstore-cli.sh
+++ b/ci/tasks/bump-bosh-blobstore-cli.sh
@@ -10,7 +10,7 @@ if [[ -n "${DEBUG:-}" ]]; then
   export BOSH_LOG_PATH="${BOSH_LOG_PATH:-${REPO_PARENT}/bosh-debug.log}"
 fi
 
-git clone "${REPO_ROOT}" "${REPO_PARENT}/bosh-linux-stemcell-builder-out"
+git clone "${REPO_PARENT}/bosh-linux-stemcell-builder" "${REPO_PARENT}/bosh-linux-stemcell-builder-out"
 
 url=$(cat "${REPO_PARENT}/bosh-blobstore-cli/url")
 version=$(cat "${REPO_PARENT}/bosh-blobstore-cli/version")

--- a/ci/tasks/commit-build-time.sh
+++ b/ci/tasks/commit-build-time.sh
@@ -13,7 +13,7 @@ fi
 build_time="$(cat "${REPO_PARENT}/build-time/timestamp")"
 formatted_build_time="$(date --date "${build_time%.*}" +%Y%m%dT%H%M%SZ)"
 
-pushd "${REPO_ROOT}"
+pushd "${REPO_PARENT}/bosh-linux-stemcell-builder"
   echo "${formatted_build_time}" > build_time.txt
   git add -A
   git config --global user.email "ci@localhost"

--- a/ci/tasks/os-images/build.sh
+++ b/ci/tasks/os-images/build.sh
@@ -35,7 +35,7 @@ sudo chmod u+s "$(which sudo)"
 sudo --preserve-env --set-home --user ubuntu -- /bin/bash --login -i <<SUDO
 set -e
 
-pushd "${REPO_ROOT}"
+pushd "${REPO_PARENT}/bosh-linux-stemcell-builder"
   bundle install
   bundle exec rake stemcell:build_os_image[$OPERATING_SYSTEM_NAME,$OPERATING_SYSTEM_VERSION,$OS_IMAGE]
 popd

--- a/ci/tasks/test-unit.sh
+++ b/ci/tasks/test-unit.sh
@@ -15,7 +15,7 @@ os_image="$(readlink -f "${REPO_PARENT}"/os-image-tarball/*.tgz)"
 # we need sudo for our chroot operations in the shellout_types tests
 apt install sudo
 
-pushd "${REPO_ROOT}/bosh-stemcell"
+pushd "${REPO_PARENT}/bosh-linux-stemcell-builder/bosh-stemcell"
   bundle install
   bundle exec rake spec
   OS_IMAGE="${os_image}" bundle exec rake spec:shellout_types


### PR DESCRIPTION
It is important that code-under-test, and tasks-in-use come from the non-CI resource `bosh-linux-stemcell-builder` and not `bosh-stemcells-ci` (current naming) so that code executed has satisfied the expected pass constraints.