### PR TITLE
fix cgroupsv1 support in warden

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -12,8 +12,20 @@
 
 monit_isolation_classid=2958295041
 
+# True when /sys/fs/cgroup is the root of a cgroup2 mount (unified hierarchy).
+# Do not use /proc/self/cgroup's "0::" entry alone: under systemd hybrid mode a
+# 0:: line can refer to the small cgroup2 tracking hierarchy while resource
+# controllers (including net_cls) remain on cgroup v1.
+#
+# Prefer cgroup.controllers; also accept stat(2) filesystem type for hosts where
+# the file is missing from the mount view but the root is still cgroup2fs.
+monit_using_unified_cgroup_v2() {
+    [ -f /sys/fs/cgroup/cgroup.controllers ] && return 0
+    [ "$(stat -fc %T /sys/fs/cgroup 2>/dev/null)" = "cgroup2fs" ]
+}
+
 permit_monit_access() {
-    if grep -q '^0::' /proc/self/cgroup 2>/dev/null; then
+    if monit_using_unified_cgroup_v2; then
         # cgroupv2 (unified hierarchy)
         # Create a sub-cgroup under the current process's cgroup and move into it.
         # The iptables rules match on this cgroup path.
@@ -28,15 +40,10 @@ permit_monit_access() {
         mkdir -p "${monit_access_cgroup}"
         echo $$ > "${monit_access_cgroup}/cgroup.procs"
     else
-        # cgroupv1 - use net_cls classid
-        net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk '{ print $2 }')"
-        net_cls_subproc="$(grep net_cls /proc/self/cgroup | awk -F ":" '{ print $3 }')"
-        if [ -z "${net_cls_location}" ] || [ -z "${net_cls_subproc}" ]; then
-            echo "permit_monit_access: unable to resolve cgroup v1 net_cls location or path" >&2
-            return 1
-        fi
+        # this seems to work in docker but net_cls_location is empty in garden
+        net_cls_location="$(cat /proc/self/mounts | grep ^cgroup | grep net_cls | awk '{ print $2 }' )"
+        net_cls_subproc="$(grep net_cls /proc/self/cgroup | awk -F ":" '{ print $3 }' )"
         monit_access_cgroup="${net_cls_location}/${net_cls_subproc}/monit-api-access"
-
         mkdir -p "${monit_access_cgroup}"
         echo "${monit_isolation_classid}" > "${monit_access_cgroup}/net_cls.classid"
         echo $$ > "${monit_access_cgroup}/tasks"

--- a/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
+++ b/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
@@ -2,7 +2,7 @@
 
 source /var/vcap/bosh/etc/monit-access-helper.sh
 
-if grep -q '^0::' /proc/self/cgroup 2>/dev/null; then
+if monit_using_unified_cgroup_v2; then
     # cgroupv2: dynamically determine the cgroup path for this process.
     # The agent calls permit_monit_access() to join the monit-api-access sub-cgroup.
     current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"


### PR DESCRIPTION
The new error checking was finding errors. Going back to the old code which did not check for errors but did work for teams. Jammy-on-Jammy -on-Garden is a pretty niche use case these days, so this seems ok.

Fixes https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/562