### PR TITLE
CI: fix build-docker-args task

### DIFF
--- a/ci/pipelines/builder.yml
+++ b/ci/pipelines/builder.yml
@@ -1060,6 +1060,7 @@ resources:
     branch: (@= data.values.stemcell_details.branch @)
     paths:
       - ci
+      - .ruby-version
     uri: https://github.com/cloudfoundry/bosh-linux-stemcell-builder
 
 - name: bats

--- a/ci/pipelines/vars.yml
+++ b/ci/pipelines/vars.yml
@@ -6,6 +6,7 @@ stemcell_details:
   os_version: "22.04"
   os_name: ubuntu-jammy
   os_short_name: jammy
+  subnet_int: "22" #! use last two digits of release year: ex 2010 -> 10
   use_efi: false
   include_iaas: [
     {iaas: alicloud, hypervisor: kvm},
@@ -21,7 +22,6 @@ stemcell_details:
     {iaas: aws, hypervisor: xen-hvm},
     {iaas: google, hypervisor: kvm},
   ]
-  subnet_int: "22" #! use last two digits of release year: ex 2000 -> 20
 
 blobstore_types:
 - dav

--- a/ci/tasks/build-docker-args.sh
+++ b/ci/tasks/build-docker-args.sh
@@ -28,7 +28,7 @@ yq_cli_url="$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest 
 ruby_install_url="$(curl -s https://api.github.com/repos/postmodern/ruby-install/releases/latest \
                     | jq -r '.assets[] | select(.name | endswith ("tar.gz")) | .browser_download_url')"
 
-ruby_version="$(cat "${REPO_PARENT}/bosh-linux-stemcell-builder/.ruby-version")"
+ruby_version="$(cat "${REPO_ROOT}/.ruby-version")"
 gem_home="/usr/local/bundle"
 
 cat << EOF > "${REPO_PARENT}/docker-build-args/docker-build-args.json"


### PR DESCRIPTION
Pipeline already reconfigured.

Fixes:

```
cat: /tmp/build/9ff7fd89/bosh-linux-stemcell-builder/.ruby-version: No such file or directory
```
^ https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-jammy-builder/jobs/build-os-image-stemcell-builder/builds/47#L69ba6d7d:128