### PR TITLE
Include netplan refactor packages in Azure dpkg list

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
@@ -7,12 +7,14 @@ linux-cloud-tools-5.15
 linux-cloud-tools-5.15-generic
 linux-cloud-tools-common
 linux-cloud-tools-generic
+netplan-generator
 netplan.io
 python-babel-localedata
 python3-attr
 python3-babel
 python3-certifi
 python3-debconf
+python3-netplan
 python3-pyrsistent:amd64
 python3-requests
 python3-serial


### PR DESCRIPTION
In
https://lists.ubuntu.com/archives/jammy-changes/2024-September/033387.html it says:
"    Packaging restructuring:
    - Split netplan-generator into separate package to make the Python
      dependency optional.
    - Split python3-netplan bindings into a separate package"

Newer Azure builds pull in this new netplan version due to cloud-init. It does not seem like there are any functional changes that we care about.