### PR TITLE
Serialize stemcell builds, and remove attempts

### DIFF
--- a/ci/pipelines/builder.yml
+++ b/ci/pipelines/builder.yml
@@ -446,6 +446,7 @@ jobs:
 
 #@ def build_stemcell(IAAS, HYPERVISOR, FIPS=""):
   name: build-(@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)
+  serial: true
   plan:
   - in_parallel:
     - get: version
@@ -468,7 +469,6 @@ jobs:
       passed:
       - build-os-image
   - task: create-stemcell
-    attempts: 3
     file: bosh-stemcells-ci/ci/tasks/build.yml
     image: os-image-stemcell-builder-registry-image
     params:


### PR DESCRIPTION
We don't really ever want these builds to stack up, and I believe the attempts: 3 just lead to longer failure cycles.