### PR TITLE
Use kernel.org mirror for debootstrap

### DIFF
--- a/ci/pipelines/builder.yml
+++ b/ci/pipelines/builder.yml
@@ -248,7 +248,7 @@ jobs:
     params:
       OPERATING_SYSTEM_NAME: ubuntu
       OPERATING_SYSTEM_VERSION: (@= data.values.stemcell_details.os_short_name @)
-      UBUNTU_DEBOOTSTRAP_MIRROR: http://gce.archive.ubuntu.com/ubuntu #! Ubuntu's GCP-internal mirror, must change if we change Concourse IaaS!
+      UBUNTU_DEBOOTSTRAP_MIRROR: http://mirrors.edge.kernel.org/ubuntu
     privileged: true
     vars:
       image_os_tag: (@= data.values.stemcell_details.os_short_name @)


### PR DESCRIPTION
Turns out, the internal GCE mirror is designed only for actual vms running in GCP, and either didn't play well with the Concourse container's egress or doesn't server jammy.

Fixes

debootstrap --arch=amd64 jammy /mnt/stemcells/null/null/ubuntu/work/work/chroot http://gce.archive.ubuntu.com/ubuntu I: Retrieving InRelease
I: Retrieving Release
E: Failed getting release file http://gce.archive.ubuntu.com/ubuntu/dists/jammy/Release

(already flown)