### PR TITLE
Add instance storage discovery patterns in config

### DIFF
--- a/bosh-stemcell/spec/stemcells/aws_spec.rb
+++ b/bosh-stemcell/spec/stemcells/aws_spec.rb
@@ -24,6 +24,22 @@ describe "AWS Stemcell", stemcell_image: true do
     end
   end
 
+  context "installed by bosh_aws_agent_settings" do
+    describe file("/var/vcap/bosh/agent.json") do
+      it { should be_valid_json_file }
+
+      it "sets InstanceStorageDevicePattern for NVMe instance storage" do
+        config = JSON.parse(subject.content)
+        expect(config.dig("Platform", "Linux", "InstanceStorageDevicePattern")).to eq("/dev/nvme*n1")
+      end
+
+      it "sets InstanceStorageManagedVolumePattern to exclude EBS volumes" do
+        config = JSON.parse(subject.content)
+        expect(config.dig("Platform", "Linux", "InstanceStorageManagedVolumePattern")).to eq("/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*")
+      end
+    end
+  end
+
   describe "nvme" do
     describe "nvme-id finder" do
       subject { file("/sbin/nvme-id") }

--- a/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
@@ -11,7 +11,9 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
       $(get_partitioner_type_mapping)
       "DevicePathResolutionType": "virtio",
       "CreatePartitionIfNoEphemeralDisk": true,
-      "UseMonitIptablesFirewall": true
+      "UseMonitIptablesFirewall": true,
+      "InstanceStorageDevicePattern": "/dev/nvme*n1",
+      "InstanceStorageManagedVolumePattern": "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*"
     }
   },
   "Infrastructure": {


### PR DESCRIPTION
Note: Should merge forward these changes to ubuntu-noble.

## Summary

Adds two config fields to the AWS agent settings baked into the stemcell, required by
cloudfoundry/bosh-agent#407 (and subsequently by https://github.com/cloudfoundry/bosh-agent/pull/396) to correctly discover NVMe instance storage on AWS Nitro
instances.

## Background

On Nitro-based instances (e.g. `m6id`, `i3en`), NVMe PCIe enumeration order is
non-deterministic — `/dev/nvme0n1` may be the root EBS volume, an attached EBS volume,
or instance storage depending on boot order. The bosh-agent now uses symlinks in
`/dev/disk/by-id/` to identify and exclude EBS volumes, leaving only instance storage.

To keep the resolver IaaS-agnostic, the AWS-specific patterns are not hardcoded in the
agent binary — they are injected via agent config at stemcell build time.

## Changes

`stemcell_builder/stages/bosh_aws_agent_settings/apply.sh`:

- `InstanceStorageDevicePattern`: glob pattern matching all NVMe namespace devices
- `InstanceStorageManagedVolumePattern`: glob pattern matching EBS volume symlinks in
  `/dev/disk/by-id/`, used to identify and exclude EBS volumes from instance storage
  discovery

## Related

- cloudfoundry/bosh-agent#407 — implements the NVMe instance storage discovery using
  these patterns
- cloudfoundry/bosh-agent#396 — original PR this refactors
- cloudfoundry/bosh-aws-cpi-release#196 — companion CPI-side change

## This repository uses a "Merge Forward" strategy

Changes should be made in the earliest applicable branch, and
merged forward through subsequent branches.
1. Create a PR into the oldest branch (`ubuntu-<short_name>`)
2. After this PR has been merged create a `merge-to-<next_short_name>` branch
3. Merge `ubuntu-<short_name>` into `merge-to-<next_short_name>`
4. Create a PR to merge `merge-to-<next_short_name>` into `ubuntu-<next_short_name>`
5. Repeat as needed for subsequent branches
