### PR TITLE
Harden monit-access-helper.sh cgroupv2 mount point detection

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -32,7 +32,7 @@ permit_monit_access() {
         cgroup_mount="$(awk '$1 == "cgroup2" && $3 == "cgroup2" { print $2 }' /proc/self/mounts)"
         nb_matching_cgroup_mounts=$(echo "$cgroup_mount" | grep -c '^.')
         current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
-        if [ -z "${cgroup_mount}" ] || [ "${nb_matching_cgroup_mounts}" -ne 1 ] || [ -z "${current_cgroup}" ]; then
+        if [ "${nb_matching_cgroup_mounts}" -ne 1 ] || [ -z "${current_cgroup}" ]; then
             echo "permit_monit_access: unable to resolve cgroup v2 mount or path. current_cgroup=${current_cgroup} cgroup_mount=${cgroup_mount} nb_matching_cgroup_mounts=${nb_matching_cgroup_mounts}" >&2
             return 1
         fi

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -33,7 +33,7 @@ permit_monit_access() {
         nb_matching_cgroup_mounts=$(echo "$cgroup_mount" | grep -c '^.')
         current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
         if [ -z "${cgroup_mount}" ] || [ "${nb_matching_cgroup_mounts}" -ne 1 ] || [ -z "${current_cgroup}" ]; then
-            echo "permit_monit_access: unable to resolve cgroup v2 mount or path. current_cgroup=${current_cgroup} cgroup_mount=${cgroup_mount}" >&2
+            echo "permit_monit_access: unable to resolve cgroup v2 mount or path. current_cgroup=${current_cgroup} cgroup_mount=${cgroup_mount} nb_matching_cgroup_mounts=${nb_matching_cgroup_mounts}" >&2
             return 1
         fi
         monit_access_cgroup="${cgroup_mount}${current_cgroup}/monit-api-access"

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -29,9 +29,10 @@ permit_monit_access() {
         # cgroupv2 (unified hierarchy)
         # Create a sub-cgroup under the current process's cgroup and move into it.
         # The iptables rules match on this cgroup path.
-        cgroup_mount="$(awk '$3 == "cgroup2" { print $2 }' /proc/self/mounts)"
+        cgroup_mount="$(awk '$1 == "cgroup2" && $3 == "cgroup2" { print $2 }' /proc/self/mounts)"
+        nb_matching_cgroup_mounts=$(echo "$cgroup_mount" | wc -l)
         current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
-        if [ -z "${cgroup_mount}" ] || [ -z "${current_cgroup}" ]; then
+        if [ -z "${cgroup_mount}" ] || [ "${nb_matching_cgroup_mounts}" -ne 1 ] || [ -z "${current_cgroup}" ]; then
             echo "permit_monit_access: unable to resolve cgroup v2 mount or path" >&2
             return 1
         fi

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -19,13 +19,13 @@ monit_isolation_classid=2958295041
 #
 # Prefer cgroup.controllers; also accept stat(2) filesystem type for hosts where
 # the file is missing from the mount view but the root is still cgroup2fs.
-monit_using_unified_cgroup_v2() {
+system_using_unified_cgroup_v2() {
     [ -f /sys/fs/cgroup/cgroup.controllers ] && return 0
     [ "$(stat -fc %T /sys/fs/cgroup 2>/dev/null)" = "cgroup2fs" ]
 }
 
 permit_monit_access() {
-    if monit_using_unified_cgroup_v2; then
+    if system_using_unified_cgroup_v2; then
         # cgroupv2 (unified hierarchy)
         # Create a sub-cgroup under the current process's cgroup and move into it.
         # The iptables rules match on this cgroup path.
@@ -33,7 +33,7 @@ permit_monit_access() {
         nb_matching_cgroup_mounts=$(echo "$cgroup_mount" | wc -l)
         current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
         if [ -z "${cgroup_mount}" ] || [ "${nb_matching_cgroup_mounts}" -ne 1 ] || [ -z "${current_cgroup}" ]; then
-            echo "permit_monit_access: unable to resolve cgroup v2 mount or path" >&2
+            echo "permit_monit_access: unable to resolve cgroup v2 mount or path. current_cgroup=${current_cgroup} cgroup_mount=${cgroup_mount}" >&2
             return 1
         fi
         monit_access_cgroup="${cgroup_mount}${current_cgroup}/monit-api-access"

--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -30,7 +30,7 @@ permit_monit_access() {
         # Create a sub-cgroup under the current process's cgroup and move into it.
         # The iptables rules match on this cgroup path.
         cgroup_mount="$(awk '$1 == "cgroup2" && $3 == "cgroup2" { print $2 }' /proc/self/mounts)"
-        nb_matching_cgroup_mounts=$(echo "$cgroup_mount" | wc -l)
+        nb_matching_cgroup_mounts=$(echo "$cgroup_mount" | grep -c '^.')
         current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
         if [ -z "${cgroup_mount}" ] || [ "${nb_matching_cgroup_mounts}" -ne 1 ] || [ -z "${current_cgroup}" ]; then
             echo "permit_monit_access: unable to resolve cgroup v2 mount or path. current_cgroup=${current_cgroup} cgroup_mount=${cgroup_mount}" >&2


### PR DESCRIPTION
Restrict the inspection of /proc/self/mounts to cgroupv2 device (1st column) in addition to existing cgroup fstype (column 3).

Also fail fast in case of multiple detected mount points.

Fix #585

----

NOTE: this repository uses a "Merge Forward" strategy

Changes should be made in the earliest applicable branch, and
merged forward through subsequent branches.
1. Create a PR into the oldest branch (`ubuntu-<short_name>`)
2. After this PR has been merged create a `merge-to-<next_short_name>` branch
3. Merge `ubuntu-<short_name>` into `merge-to-<next_short_name>`
4. Create a PR to merge `merge-to-<next_short_name>` into `ubuntu-<next_short_name>`
5. Repeat as needed for subsequent branches
