### PR TITLE
Revert "Revert "More module refactoring""

### DIFF
--- a/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
@@ -95,4 +95,22 @@ shared_examples_for "a Linux kernel module configured OS image" do
       its(:content) { should match "install algif_aead /bin/true" }
     end
   end
+
+  context "prevent esp4 module from being loaded" do
+    describe file("/etc/modprobe.d/blacklist.conf") do
+      its(:content) { should match "install esp4 /bin/true" }
+    end
+  end
+
+  context "prevent esp6 module from being loaded" do
+    describe file("/etc/modprobe.d/blacklist.conf") do
+      its(:content) { should match "install esp6 /bin/true" }
+    end
+  end
+
+  context "prevent rxrpc module from being loaded" do
+    describe file("/etc/modprobe.d/blacklist.conf") do
+      its(:content) { should match "install rxrpc /bin/true" }
+    end
+  end
 end

--- a/stemcell_builder/stages/system_kernel_modules/apply.sh
+++ b/stemcell_builder/stages/system_kernel_modules/apply.sh
@@ -21,6 +21,9 @@ install udf /bin/true
 install rds /bin/true
 install floppy /bin/true
 install algif_aead /bin/true
+install esp4 /bin/true
+install esp6 /bin/true
+install rxrpc /bin/true
 options ipv6 disable=1' >> $chroot/etc/modprobe.d/blacklist.conf
 
 echo '# prevent nouveau from loading


### PR DESCRIPTION
Reverts cloudfoundry/bosh-linux-stemcell-builder#606 (The USN https://ubuntu.com/security/notices/USN-8373-1 did not patch the 5.15 kernel!!!)