### PR TITLE
Backport AppArmor dhclient local override for LP #2011628

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
@@ -1,3 +1,8 @@
+# @AI-Generated
+# Modified with AI assistance
+# Description:
+# 2026-06-04: Add spec for AppArmor local dhclient override (LP #2011628 backport) - Cursor: Claude Sonnet 4.6
+
 require "spec_helper"
 
 describe "Ubuntu 22.04 stemcell image", stemcell_image: true do
@@ -187,6 +192,13 @@ describe "Ubuntu 22.04 stemcell image", stemcell_image: true do
         # expect(subject.stdout.split).to match_array(%w(/bin/su /usr/bin/sudo /usr/bin/sudoedit))
         expect(subject.stdout.split).to match_array(%w[/bin/su /bin/sudo /bin/sudoedit /usr/bin/su /usr/bin/sudo /usr/bin/sudoedit])
       end
+    end
+  end
+
+  context "installed by base_ubuntu_packages" do
+    describe file("/etc/apparmor.d/local/sbin.dhclient") do
+      it { should be_file }
+      its(:content) { should match(%r{\{,usr/\}bin/true ixr,}) }
     end
   end
 

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# @AI-Generated
+# Modified with AI assistance
+# Description:
+# 2026-06-04: Install AppArmor local dhclient override (LP #2011628 backport) - Cursor: Claude Sonnet 4.6
 
 set -e
 
@@ -33,6 +37,12 @@ run_in_chroot "${chroot}" "systemctl enable systemd-networkd-resolvconf-update.p
 run_in_chroot "${chroot}" "systemctl enable systemd-networkd-resolvconf-update.service"
 
 pkg_mgr install $debs
+
+# Backport LP #2011628: allow dhclient to exec /bin/true (used by cloud-init
+# with -sf /bin/true). Canonical fixed this in Mantic but not Jammy.
+mkdir -p "${chroot}/etc/apparmor.d/local"
+cp "$(dirname "$0")/assets/apparmor-local-sbin.dhclient" \
+   "${chroot}/etc/apparmor.d/local/sbin.dhclient"
 
 run_in_chroot $chroot "add-apt-repository ppa:adiscon/v8-stable"
 pkg_mgr install "rsyslog rsyslog-gnutls rsyslog-openssl rsyslog-mmjsonparse rsyslog-mmnormalize rsyslog-relp"

--- a/stemcell_builder/stages/base_ubuntu_packages/assets/apparmor-local-sbin.dhclient
+++ b/stemcell_builder/stages/base_ubuntu_packages/assets/apparmor-local-sbin.dhclient
@@ -1,0 +1,5 @@
+# Local override for sbin.dhclient - allow dhclient to exec /bin/true as a
+# no-op script substitute (used by cloud-init with -sf /bin/true). Backports
+# the fix for Ubuntu Launchpad Bug #2011628 which was shipped in Mantic but
+# not backported to Jammy.
+/{,usr/}bin/true ixr,


### PR DESCRIPTION
## Why
Commit [570990c6e](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/570990c6e) enabled AppArmor enforcement (`apparmor=1 security=apparmor`) on Jammy stemcells. Ubuntu Jammy's `isc-dhcp-client` package ships an AppArmor profile (`/etc/apparmor.d/sbin.dhclient`) that only permits `dhclient-script` as the exit script — not arbitrary binaries.

During the `cloud-init-local` stage, cloud-init invokes:
```
/usr/sbin/dhclient -1 -v -lf /run/dhclient.lease -pf /run/dhclient.pid eth0 -sf /bin/true
```

The `-sf /bin/true` substitution (a no-op that suppresses `dhclient-script` side effects during early metadata fetching) is denied by AppArmor. This causes dhclient to fail, leaving the VM with an incorrect DHCP-assigned IP instead of its pre-allocated one until dhclient is retried after cloud-init completes.

This is [Ubuntu Launchpad Bug #2011628 — "Apparmor Disallows Disabling Dhclient Scripts"](https://bugs.launchpad.net/bugs/2011628). Canonical fixed it in [`isc-dhcp 4.4.3-P1-1ubuntu2`](https://launchpad.net/ubuntu/+source/isc-dhcp/4.4.3-P1-1ubuntu2) for Ubuntu Mantic (23.10) in March 2023 ([changelog](https://changelogs.ubuntu.com/changelogs/pool/main/i/isc-dhcp/isc-dhcp_4.4.3-P1-1ubuntu2/changelog)), but as of the current Jammy package (`4.4.1-2.3ubuntu2.4`) the fix has [not been backported](https://bugs.launchpad.net/ubuntu/+source/isc-dhcp/+bug/2011628).
## What
Adds `/etc/apparmor.d/local/sbin.dhclient` in the Jammy stemcell containing the rule from the Mantic fix:
```
/{,usr/}bin/true ixr,
```

The `local/` directory is included by the base `sbin.dhclient` AppArmor profile, so this rule is merged at AppArmor load time with no other changes needed. When Canonical eventually backports the fix to Jammy the file will become a harmless duplicate.