### PR TITLE
CI: remove (future) deprecated `--preserve-env` flag

### DIFF
--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -77,13 +77,17 @@ chown -R ubuntu:ubuntu "${REPO_PARENT}/bosh-linux-stemcell-builder"
 chown -R ubuntu:ubuntu /mnt
 sudo chmod u+s "$(which sudo)"
 
-sudo --preserve-env --set-home --user ubuntu -- /bin/bash --login -i <<SUDO
+sudo --set-home --user ubuntu -- \
+  env GEM_HOME="${GEM_HOME}" \
+      UBUNTU_ADVANTAGE_TOKEN="${UBUNTU_ADVANTAGE_TOKEN:-}" \
+      UBUNTU_FIPS_USE_IAAS_KERNEL="${UBUNTU_FIPS_USE_IAAS_KERNEL:-}" \
+  /bin/bash --login -i <<SUDO
 set -e
 
 cd "${REPO_PARENT}/bosh-linux-stemcell-builder"
 bundle install
 
-bundle exec rake stemcell:build[${IAAS},${HYPERVISOR},${OS_NAME},${OS_VERSION},${OS_IMAGE},${CANDIDATE_BUILD_NUMBER}]
+bundle exec rake "stemcell:build[${IAAS},${HYPERVISOR},${OS_NAME},${OS_VERSION},${OS_IMAGE},${CANDIDATE_BUILD_NUMBER}]"
 SUDO
 
 #

--- a/ci/tasks/os-images/build.sh
+++ b/ci/tasks/os-images/build.sh
@@ -35,11 +35,16 @@ chown -R ubuntu:ubuntu "${REPO_PARENT}/bosh-linux-stemcell-builder"
 chown -R ubuntu:ubuntu /mnt
 sudo chmod u+s "$(which sudo)"
 
-sudo --preserve-env --set-home --user ubuntu -- /bin/bash --login -i <<SUDO
+sudo --set-home --user ubuntu -- \
+  env GEM_HOME="${GEM_HOME}" \
+      BUILD_TIME="${BUILD_TIME:-}" \
+      UBUNTU_ADVANTAGE_TOKEN="${UBUNTU_ADVANTAGE_TOKEN:-}" \
+      UBUNTU_DEBOOTSTRAP_MIRROR="${UBUNTU_DEBOOTSTRAP_MIRROR:-}" \
+  /bin/bash --login -i <<SUDO
 set -e
 
 cd "${REPO_PARENT}/bosh-linux-stemcell-builder"
 bundle install
 
-bundle exec rake stemcell:build_os_image[$OPERATING_SYSTEM_NAME,$OPERATING_SYSTEM_VERSION,$OS_IMAGE]
+bundle exec rake "stemcell:build_os_image[${OPERATING_SYSTEM_NAME},${OPERATING_SYSTEM_VERSION},${OS_IMAGE}]"
 SUDO


### PR DESCRIPTION
- explicitly pass GEM_HOME

Fixes:
```
sudo: preserving the entire environment is not supported, '--preserve-env' is ignored
ubuntu@21f652d6-b208-4386-b0c0-097e26578228:/tmp/build/44575cf5$ set -e
ubuntu@21f652d6-b208-4386-b0c0-097e26578228:/tmp/build/44575cf5$
ubuntu@21f652d6-b208-4386-b0c0-097e26578228:/tmp/build/44575cf5$ cd "/tmp/build/44575cf5/bosh-linux-stemcell-builder"
ubuntu@21f652d6-b208-4386-b0c0-097e26578228:/tmp/build/44575cf5/bosh-linux-stemcell-builder$ bundle install
Bundler 4.0.13 is running, but your lockfile was generated with 2.5.23. Installing Bundler 2.5.23 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.5.23

Retrying download gem from https://rubygems.org/ due to error (2/4): Bundler::PermissionError There was an error while trying to write to `/usr/local/lib/ruby/gems/3.3.0/cache/bundler-2.5.23.gem`. It is likely that you need to grant write permissions for that path.
```
^ https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-resolute-builder/jobs/build-os-image/builds/1#L6a052874:4:13

