### PR TITLE
fix(resolute): remove obsolete metadata_csum workaround and update Az…

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu-azure-additions.txt
@@ -1,7 +1,9 @@
 azure-vm-utils
 cloud-init
-linux-cloud-tools-6.8
-linux-cloud-tools-6.8-generic
+cloud-init-base
+libjs-sphinxdoc
+linux-cloud-tools-7.0
+linux-cloud-tools-7.0-generic
 linux-cloud-tools-common
 linux-cloud-tools-generic
 netplan.io
@@ -16,10 +18,12 @@ python3-jinja2
 python3-json-pointer
 python3-jsonpatch
 python3-jsonschema
+python3-jsonschema-specifications
 python3-markupsafe
+python3-passlib
 python3-pyasn1
-python3-pyrsistent:amd64
+python3-referencing
 python3-requests
+python3-rpds-py
 python3-serial
-python3-setuptools
 python3-urllib3

--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -458,7 +458,6 @@ python3-pkg-resources
 python3-pygments
 python3-pyparsing
 python3-rich
-python3-setuptools
 python3-software-properties
 python3-typeguard
 python3-typing-extensions

--- a/bosh-stemcell/spec/stemcells/alicloud_spec.rb
+++ b/bosh-stemcell/spec/stemcells/alicloud_spec.rb
@@ -16,12 +16,4 @@ describe "AliCloud Stemcell", stemcell_image: true do
       its(:content) { should match(/^PasswordAuthentication no$/) }
     end
   end
-
-  context "ext4 filesystems" do
-    describe "should not contain ext4 feature metadata_csum" do
-      subject { file("/etc/mke2fs.conf") }
-
-      its(:content) { should_not match(/metadata_csum/) }
-    end
-  end
 end

--- a/stemcell_builder/stages/system_alicloud/apply.sh
+++ b/stemcell_builder/stages/system_alicloud/apply.sh
@@ -4,8 +4,3 @@ set -e
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-
-# Alicloud does not support ext4 feature 'metadata_csum'.
-# Remove it from root image and also disable it inside image for all ext4 filesystems created afterwards.
-sed -i "s/metadata_csum,//g" /etc/mke2fs.conf
-sed -i "s/metadata_csum,//g" $chroot/etc/mke2fs.conf


### PR DESCRIPTION
Fix resolute stemcell builds for azure and alicloud.

This PR replaces #631 due to some github wierdness.

## AI Slop Summary
Ubuntu 26.04 ships with GRUB 2.12+ which supports metadata_csum_seed
natively (fixed upstream June 2021). The sed workaround in
system_alicloud/apply.sh was a no-op on Resolute (pattern 'metadata_csum,'
does not match 'metadata_csum_seed,') and is no longer needed.

Update the Azure stemcell package list to reflect Ubuntu 26.04 (Resolute)
changes: kernel cloud-tools bumped from 6.8 to 7.0, python3-pyrsistent
replaced by python3-rpds-py, cloud-init-base split added, new jsonschema
dependencies added (python3-jsonschema-specifications, python3-referencing),
python3-passlib added, python3-setuptools removed (not installed by default
in 26.04).