### PR TITLE
add python3-setuptools back to dpkg-list-ubuntu.txt

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -458,6 +458,7 @@ python3-pkg-resources
 python3-pygments
 python3-pyparsing
 python3-rich
+python3-setuptools
 python3-software-properties
 python3-typeguard
 python3-typing-extensions


### PR DESCRIPTION
This shouldn't have been removed in #632 