### PR TITLE
Fix sshd auditd spec for resolute

### DIFF
--- a/acceptance-tests/ipv4director/auditd/smoke_test.go
+++ b/acceptance-tests/ipv4director/auditd/smoke_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Auditd", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exitStatus).To(Equal(0))
 
-		auditLoginRegexp := `.*type=USER_LOGIN.*exe="/usr/sbin/sshd".*res=success`
+		auditLoginRegexp := `.*type=USER_LOGIN.*exe="/usr/lib/openssh/sshd-session".*res=success`
 		Expect(output).To(MatchRegexp(auditLoginRegexp))
 	})
 })


### PR DESCRIPTION
Ubuntu Resolute moved session handling to sshd-session so the log line is different. Updating auditd spec to match.