### PR TITLE
Add NVMe support to Alicloud infrastructure configuration

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/infrastructure.rb
@@ -141,7 +141,10 @@ module Bosh::Stemcell
       end
 
       def additional_cloud_properties
-        {"root_device_name" => "/dev/vda1"}
+        {
+          "root_device_name" => "/dev/vda1",
+          "nvme_support" => "supported"
+        }
       end
     end
 

--- a/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb
@@ -92,6 +92,24 @@ module Bosh::Stemcell
     end
   end
 
+  describe Infrastructure::Alicloud do
+    its(:name) { should eq("alicloud") }
+    its(:hypervisor) { should eq("kvm") }
+    its(:default_disk_size) { should eq(5120) }
+    its(:disk_formats) { should eq(["raw"]) }
+    its(:stemcell_formats) { should eq(["alicloud-raw"]) }
+
+    it { should eq Infrastructure.for("alicloud") }
+    it { should_not eq Infrastructure.for("aws") }
+
+    it "has alicloud specific additional cloud properties" do
+      expect(subject.additional_cloud_properties).to eq({
+        "root_device_name" => "/dev/vda1",
+        "nvme_support" => "supported"
+      })
+    end
+  end
+
   describe Infrastructure::Google do
     its(:name) { should eq("google") }
     its(:hypervisor) { should eq("kvm") }


### PR DESCRIPTION
NOTE: this repository uses a "Merge Forward" strategy. This PR is merge forwarded from ubuntu-jammy - https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/635

## Add nvme_support cloud property for AliCloud stemcells

AliCloud instance families (c9i, g9i, r9i) require stemcell images to have Features.NvmeSupport=supported set in ECS. Previously the CPI was enabling this unconditionally for all AliCloud stemcells, which couples infrastructure-specific behaviour to the CPI rather than to the stemcell definition.

This change adds "nvme_support": "supported" to Alicloud#additional_cloud_properties in the infrastructure definition. The value is written into cloud_properties in stemcell.MF at build time, alongside the existing root_device_name property. CPIs can read this field to decide whether to enable NVMe support when importing or copying a stemcell image, rather than inferring it from the infrastructure name.

No other infrastructure is affected.

## Changes

- bosh-stemcell/lib/bosh/stemcell/infrastructure.rb — added "nvme_support" => "supported" to Alicloud#additional_cloud_properties
- bosh-stemcell/spec/bosh/stemcell/infrastructure_spec.rb — added missing describe Infrastructure::Alicloud block with nvme_support assertion (the AliCloud infrastructure had no unit tests before this change)