### PR TITLE
Fix issue 637

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
+++ b/stemcell_builder/stages/bosh_monit/assets/monit-access-helper.sh
@@ -29,7 +29,7 @@ permit_monit_access() {
         # cgroupv2 (unified hierarchy)
         # Create a sub-cgroup under the current process's cgroup and move into it.
         # The iptables rules match on this cgroup path.
-        cgroup_mount="$(awk '$3 == "cgroup2" { print $2 }' /proc/self/mounts)"
+        cgroup_mount="$(awk '$3 == "cgroup2" { print $2; exit }' /proc/self/mounts)"
         current_cgroup="$(grep '^0::' /proc/self/cgroup | cut -d: -f3)"
         if [ -z "${cgroup_mount}" ] || [ -z "${current_cgroup}" ]; then
             echo "permit_monit_access: unable to resolve cgroup v2 mount or path" >&2


### PR DESCRIPTION
Reverts #599 with #638, and harden cgroupv2 mounts detection by selecting the first mount

Hope this helps. Note that I'm unable to do further tests, and rely on suggested fix by @colins in https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/637

> This was root-caused and verified by manually patching the three issues in a running stemcell 1.1234 container, after which the BOSH agent bootstrapped successfully.
----

1e4a11482 was filtering on the cgroupv2 device to prevent a `cgroup_mount` variable with multiline content failing downsteam without clear errors.

cilium-originating mount
```
cat /proc/self/mounts | grep cgroup2
     # device  mount_point         fs_type dummy
    cgroup2 /sys/fs/cgroup/unified cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
    none    /run/cilium/cgroupv2   cgroup2 rw,relatime 0 0
```

however, in warden/docker stemcells, the device is cgroup, which introduced regression #637
```
cat /proc/self/mounts | grep cgroup2
     # device  mount_point         fs_type dummy
     cgroup  /sys/fs/cgroup        cgroup2 rw,...
```

Applying suggestion by @colins in https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/637 to instead rely on the chronological ordering of mount points, and select the canonical cgroup2 mount point first added by the kernel during boot process.

https://man7.org/linux/man-pages/man5/proc_pid_mounts.5.html
> /proc/self/mounts, lists the mounts of the process's own mount namespace.  The format of this file is documented in [fstab(5)](https://man7.org/linux/man-pages/man5/fstab.5.html).

https://man7.org/linux/man-pages/man5/fstab.5.html
> The order of records in fstab is important because [fsck(8)](https://man7.org/linux/man-pages/man8/fsck.8.html), [mount(8)](https://man7.org/linux/man-pages/man8/mount.8.html), and [umount(8)](https://man7.org/linux/man-pages/man8/umount.8.html)
>        sequentially iterate through fstab doing their thing

https://man7.org/linux/man-pages/man7/cgroups.7.html
>   Note that on many modern systems, systemd(1) automatically mounts
>        the cgroup2 filesystem at /sys/fs/cgroup/unified during the boot
>        process.