### PR TITLE
fix: replace files dropped in merge forward

### DIFF
--- a/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
@@ -6,7 +6,10 @@
       "CreatePartitionIfNoEphemeralDisk": true,
       "ServiceManager": "systemd",
       "DiskIDTransformPattern": "^vol-(.+)$",
-      "DiskIDTransformReplacement": "nvme-Amazon_Elastic_Block_Store_vol${1}"
+      "DiskIDTransformReplacement": "nvme-Amazon_Elastic_Block_Store_vol${1}",
+      "UseMonitIptablesFirewall": true,
+      "InstanceStorageDevicePattern": "/dev/nvme*n1",
+      "InstanceStorageManagedVolumePattern": "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*"
     }
   },
   "Infrastructure": {


### PR DESCRIPTION
Fixes:
```
  1) AWS Stemcell installed by bosh_aws_agent_settings /var/vcap/bosh/agent.json sets InstanceStorageDevicePattern for NVMe instance storage
     Failure/Error: expect(config.dig("Platform", "Linux", "InstanceStorageDevicePattern")).to eq("/dev/nvme*n1")
     
       expected: "/dev/nvme*n1"
            got: nil
     
       (compared using ==)
     # ./spec/stemcells/aws_spec.rb:33:in `block (4 levels) in <top (required)>'

  2) AWS Stemcell installed by bosh_aws_agent_settings /var/vcap/bosh/agent.json sets InstanceStorageManagedVolumePattern to exclude EBS volumes
     Failure/Error: expect(config.dig("Platform", "Linux", "InstanceStorageManagedVolumePattern")).to eq("/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*")
     
       expected: "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*"
            got: nil
     
       (compared using ==)
     # ./spec/stemcells/aws_spec.rb:38:in `block (4 levels) in <top (required)>'
```
^ https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-noble-builder/jobs/build-aws-xen-hvm/builds/631#L6a2a20e2:15435:15451