### PR TITLE
refactor: align jammy agent settings to cp+assets approach

### DIFF
--- a/stemcell_builder/lib/prelude_agent.bash
+++ b/stemcell_builder/lib/prelude_agent.bash
@@ -1,4 +1,0 @@
-
-function get_partitioner_type_mapping {
-  echo '"PartitionerType": "parted",'
-}

--- a/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh
@@ -2,32 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      $(get_partitioner_type_mapping)
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio",
-      "UseMonitIptablesFirewall": true
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "HTTP",
-          "URI": "http://100.100.100.200",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
-        }
-      ],
-      "UseServerName": false,
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_alicloud_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_alicloud_agent_settings/assets/agent.json
@@ -1,0 +1,25 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "virtio",
+      "UseMonitIptablesFirewall": true
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "http://100.100.100.200",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
+        }
+      ],
+      "UseServerName": false,
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
@@ -2,34 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      $(get_partitioner_type_mapping)
-      "DevicePathResolutionType": "virtio",
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "UseMonitIptablesFirewall": true,
-      "InstanceStorageDevicePattern": "/dev/nvme*n1",
-      "InstanceStorageManagedVolumePattern": "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*"
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "HTTP",
-          "URI": "http://169.254.169.254",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key",
-          "TokenPath": "/latest/api/token"
-        }
-      ],
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
@@ -1,0 +1,27 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "DevicePathResolutionType": "virtio",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "UseMonitIptablesFirewall": true,
+      "InstanceStorageDevicePattern": "/dev/nvme*n1",
+      "InstanceStorageManagedVolumePattern": "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*"
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "http://169.254.169.254",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key",
+          "TokenPath": "/latest/api/token"
+        }
+      ],
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_azure_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_azure_agent_settings/apply.sh
@@ -3,29 +3,5 @@
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-# Set SettingsPath but never use it because file_meta_service is avaliable only when the settings file exists.
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "scsi",
-      "PartitionerType": "parted",
-      "UseMonitIptablesFirewall": true
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "File",
-          "MetaDataPath": "",
-          "UserDataPath": "/var/lib/cloud/instance/user-data.txt",
-          "SettingsPath": "/var/lib/cloud/instance/user-data.txt"
-        }
-      ],
-      "UseServerName": true
-    }
-  }
-}
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_azure_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_azure_agent_settings/assets/agent.json
@@ -1,0 +1,23 @@
+{
+  "Platform": {
+    "Linux": {
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "scsi",
+      "PartitionerType": "parted",
+      "UseMonitIptablesFirewall": true
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "File",
+          "MetaDataPath": "",
+          "UserDataPath": "/var/lib/cloud/instance/user-data.txt",
+          "SettingsPath": "/var/lib/cloud/instance/user-data.txt"
+        }
+      ],
+      "UseServerName": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/apply.sh
@@ -2,34 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
-agent_settings_file=$chroot/var/vcap/bosh/agent.json
-
-cat > $agent_settings_file <<JSON
-{
-  "Platform": {
-    "Linux": {
-      $(get_partitioner_type_mapping)
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio",
-      "UseMonitIptablesFirewall": true
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "HTTP",
-          "URI": "http://169.254.169.254:39724",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys"
-        }
-      ],
-      "UseServerName": true,
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_cloudstack_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_cloudstack_agent_settings/assets/agent.json
@@ -1,0 +1,25 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "virtio",
+      "UseMonitIptablesFirewall": true
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "http://169.254.169.254:39724",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys"
+        }
+      ],
+      "UseServerName": true,
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
@@ -2,35 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      "CreatePartitionIfNoEphemeralDisk": true,
-      $(get_partitioner_type_mapping)
-      "DevicePathResolutionType": "virtio",
-      "VirtioDevicePrefix": "google",
-      "UseMonitIptablesFirewall": true
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "InstanceMetadata",
-          "URI": "http://169.254.169.254",
-          "SettingsPath": "/computeMetadata/v1/instance/attributes/bosh_settings",
-          "Headers": {
-            "Metadata-Flavor": "Google"
-          }
-        }
-      ],
-
-      "UseServerName": true,
-      "UseRegistry": false
-    }
-  }
-}
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_google_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_google_agent_settings/assets/agent.json
@@ -1,0 +1,27 @@
+{
+  "Platform": {
+    "Linux": {
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "PartitionerType": "parted",
+      "DevicePathResolutionType": "virtio",
+      "VirtioDevicePrefix": "google",
+      "UseMonitIptablesFirewall": true
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "InstanceMetadata",
+          "URI": "http://169.254.169.254",
+          "SettingsPath": "/computeMetadata/v1/instance/attributes/bosh_settings",
+          "Headers": {
+            "Metadata-Flavor": "Google"
+          }
+        }
+      ],
+      "UseServerName": true,
+      "UseRegistry": false
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
@@ -2,48 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
-agent_settings_file=$chroot/var/vcap/bosh/agent.json
-
-cat > $agent_settings_file <<JSON
-{
-  "Platform": {
-    "Linux": {
-      $(get_partitioner_type_mapping)
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "DevicePathResolutionType": "virtio",
-      "UseMonitIptablesFirewall": true
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "File",
-          "SettingsPath": "/var/vcap/bosh/agent-bootstrap-env.json"
-        },
-        {
-          "Type": "ConfigDrive",
-          "DiskPaths": [
-            "/dev/disk/by-label/CONFIG-2",
-            "/dev/disk/by-label/config-2"
-          ],
-          "MetaDataPath": "ec2/latest/meta-data.json",
-          "UserDataPath": "ec2/latest/user-data"
-        },
-        {
-          "Type": "HTTP",
-          "URI": "http://169.254.169.254",
-          "UserDataPath": "/latest/user-data",
-          "InstanceIDPath": "/latest/meta-data/instance-id",
-          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
-        }
-      ],
-
-      "UseServerName": true,
-      "UseRegistry": true
-    }
-  }
-}
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_openstack_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/assets/agent.json
@@ -1,0 +1,38 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "DevicePathResolutionType": "virtio",
+      "UseMonitIptablesFirewall": true
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "File",
+          "SettingsPath": "/var/vcap/bosh/agent-bootstrap-env.json"
+        },
+        {
+          "Type": "ConfigDrive",
+          "DiskPaths": [
+            "/dev/disk/by-label/CONFIG-2",
+            "/dev/disk/by-label/config-2"
+          ],
+          "MetaDataPath": "ec2/latest/meta-data.json",
+          "UserDataPath": "ec2/latest/user-data"
+        },
+        {
+          "Type": "HTTP",
+          "URI": "http://169.254.169.254",
+          "UserDataPath": "/latest/user-data",
+          "InstanceIDPath": "/latest/meta-data/instance-id",
+          "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"
+        }
+      ],
+      "UseServerName": true,
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_softlayer_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_softlayer_agent_settings/apply.sh
@@ -2,33 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
-# Set SettingsPath but never use it because file_meta_service is available only when the settings file exists.
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      $(get_partitioner_type_mapping)
-      "CreatePartitionIfNoEphemeralDisk": true,
-      "ScrubEphemeralDisk": true,
-      "DevicePathResolutionType": "iscsi",
-      "UseMonitIptablesFirewall": true
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "HTTP",
-          "URI": "https://api.service.softlayer.com",
-          "UserDataPath": "/rest/v3.1/SoftLayer_Resource_Metadata/getUserMetadata.json"
-        }
-      ],
-      "UseServerName": true,
-      "UseRegistry": true
-    }
-  }
-}
-
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_softlayer_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_softlayer_agent_settings/assets/agent.json
@@ -1,0 +1,24 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "CreatePartitionIfNoEphemeralDisk": true,
+      "ScrubEphemeralDisk": true,
+      "DevicePathResolutionType": "iscsi",
+      "UseMonitIptablesFirewall": true
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "HTTP",
+          "URI": "https://api.service.softlayer.com",
+          "UserDataPath": "/rest/v3.1/SoftLayer_Resource_Metadata/getUserMetadata.json"
+        }
+      ],
+      "UseServerName": true,
+      "UseRegistry": true
+    }
+  }
+}

--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/apply.sh
@@ -2,28 +2,6 @@
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
-source $base_dir/lib/prelude_agent.bash
 
-cat > $chroot/var/vcap/bosh/agent.json <<JSON
-{
-  "Platform": {
-    "Linux": {
-      $(get_partitioner_type_mapping)
-      "DevicePathResolutionType": "scsi",
-      "UseMonitIptablesFirewall": true
-    }
-  },
-  "Infrastructure": {
-    "Settings": {
-      "Sources": [
-        {
-          "Type": "VsphereGuestInfo"
-        }, {
-          "Type": "CDROM",
-          "FileName": "env"
-        }
-      ]
-    }
-  }
-}
-JSON
+# shellcheck disable=SC2154
+cp "$assets_dir/agent.json" "$chroot/var/vcap/bosh/agent.json"

--- a/stemcell_builder/stages/bosh_vsphere_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_vsphere_agent_settings/assets/agent.json
@@ -1,0 +1,22 @@
+{
+  "Platform": {
+    "Linux": {
+      "PartitionerType": "parted",
+      "DevicePathResolutionType": "scsi",
+      "UseMonitIptablesFirewall": true
+    }
+  },
+  "Infrastructure": {
+    "Settings": {
+      "Sources": [
+        {
+          "Type": "VsphereGuestInfo"
+        },
+        {
+          "Type": "CDROM",
+          "FileName": "env"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Replace heredoc-based `apply.sh` scripts with static `assets/agent.json` files (the same approach already used on ubuntu-noble). This makes the two branches structurally identical so future jammy->noble merge forwards cannot silently resolve `apply.sh` conflicts in favor of the wrong version.
As seen here: #644 

- Delete `prelude_agent.bash` (PartitionerType: parted is now inlined as a static field in each `assets/agent.json`, as the function has unconditionally returned that string since 59a9c29c7 in 2019)
- Replace all 8 `bosh_*_agent_settings/apply.sh` heredocs with a single `cp $assets_dir/agent.json` line
- Add `assets/agent.json` for every stage carrying the full config (including `UseMonitIptablesFirewall` added in 8104abdd1)