### PR TITLE
fix: add get for bpm-release resource

### DIFF
--- a/ci/pipelines/builder.yml
+++ b/ci/pipelines/builder.yml
@@ -450,6 +450,7 @@ jobs:
       - get: bosh-linux-stemcell-builder
       - get: bosh-deployment
       - get: syslog-release
+      - get: bpm-release
       - get: os-conf-release
       - get: stemcell
         passed:
@@ -517,6 +518,7 @@ jobs:
       - get: bosh-linux-stemcell-builder
       - get: bosh-deployment
       - get: syslog-release
+      - get: bpm-release
       - get: os-conf-release
       - get: stemcell
         passed:


### PR DESCRIPTION
NOTE: this repository uses a "Merge Forward" strategy

Changes should be made in the earliest applicable branch, and
merged forward through subsequent branches.
1. PR should be created against the oldest stemcell branch, ex: `ubuntu-<short_name-N>`
2. After this PR has been merged create a PR to merge `ubuntu-<short_name-N>` into `ubuntu-<short_name-N+1>`
3. Repeat as needed for subsequent stemcell line branches
