### PR TITLE
CI: add flag for ipv6 testing

### DIFF
--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -568,6 +568,7 @@ jobs:
         timeout: 15m
   serial: true
 
+#@ if data.values.stemcell_details.test_ipv6:
 - name: test-stemcells-ipv6
   plan:
   - do:
@@ -636,6 +637,7 @@ jobs:
         attempts: 3
         timeout: 15m
   serial: true
+#@ end
 
 #@ for iaas in data.values.stemcell_details.include_iaas:
 - #@ build_stemcell(iaas.iaas, iaas.hypervisor)

--- a/ci/pipeline-vars.yml
+++ b/ci/pipeline-vars.yml
@@ -9,6 +9,7 @@ stemcell_details:
   os_short_name: jammy
   subnet_int: "22" #! use last two digits of release year: ex 2010 -> 10
   use_efi: false
+  test_ipv6: true
   bot_email: infra@cloudfoundry.org
   bot_name: CI Bot
   include_iaas: [


### PR DESCRIPTION
This change is a no-op for Jammy but will be useful in Noble and Resolute once they support IPv6