### PR TITLE
ci: remove `old_name` now that pipelines are configured

### DIFF
--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -1006,7 +1006,6 @@ jobs:
       #!- #@ cleanup_unpublished_light_stemcells("cn")
 
 - name: create-light-aws-(@= data.values.stemcell_details.os_name @)-(@= str(data.values.stemcell_details.major_version) @)
-  old_name: build-light-aws-(@= data.values.stemcell_details.os_name @)-(@= str(data.values.stemcell_details.major_version) @)
   plan:
     - get: bosh-stemcells-ci
     - get: aws-light-stemcell-builder-registry-image
@@ -1096,7 +1095,6 @@ jobs:
   serial: true
 
 - name: create-light-google-(@= data.values.stemcell_details.os_name @)-(@= str(data.values.stemcell_details.major_version) @)
-  old_name: build-light-google-(@= data.values.stemcell_details.os_name @)-(@= str(data.values.stemcell_details.major_version) @)
   plan:
     - in_parallel:
         - get: stemcell


### PR DESCRIPTION
NOTE: this repository uses a "Merge Forward" strategy

Changes should be made in the earliest applicable branch, and
merged forward through subsequent branches.
1. PR should be created against the oldest stemcell branch, ex: `ubuntu-<short_name-N>`
2. After this PR has been merged create a PR to merge `ubuntu-<short_name-N>` into `ubuntu-<short_name-N+1>`
3. Repeat as needed for subsequent stemcell line branches
