### PR TITLE
fix: remove UseMonitIptablesFirewall from ubuntu-noble agent settings

### DIFF
--- a/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/assets/agent.json
@@ -7,7 +7,6 @@
       "ServiceManager": "systemd",
       "DiskIDTransformPattern": "^vol-(.+)$",
       "DiskIDTransformReplacement": "nvme-Amazon_Elastic_Block_Store_vol${1}",
-      "UseMonitIptablesFirewall": true,
       "InstanceStorageDevicePattern": "/dev/nvme*n1",
       "InstanceStorageManagedVolumePattern": "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_*"
     }

--- a/stemcell_builder/stages/bosh_softlayer_agent_settings/assets/agent.json
+++ b/stemcell_builder/stages/bosh_softlayer_agent_settings/assets/agent.json
@@ -4,8 +4,7 @@
       "PartitionerType": "parted",
       "CreatePartitionIfNoEphemeralDisk": true,
       "ScrubEphemeralDisk": true,
-      "DevicePathResolutionType": "iscsi",
-      "UseMonitIptablesFirewall": true
+      "DevicePathResolutionType": "iscsi"
     }
   },
   "Infrastructure": {


### PR DESCRIPTION
It is only correct for jammy stemcells, which use an iptables-based monit access control path (cgroupv1 net_cls + monit-access-helper.sh).

On noble, setting this flag causes the bosh-agent to skip nftables monit firewall setup entirely (SetupFirewall returns early), leaving the monit_access_jobs nftables chain uncreated. The noble stemcell has no monit-access-helper.sh, so neither iptables nor nftables monit rules are created. Any job pre-start calling bosh-enable-monit-access then fails with exit 1 because the expected chain is absent, breaking all stemcell updates.
