### PR TITLE
docs: add rosetta stemcell example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ bundle exec rake stemcell:build[vsphere,esxi,ubuntu,${short_name},${PWD}/tmp/ubu
 
  # build warden (BOSH Lite) stemcell
 bundle exec rake stemcell:build[warden,warden,ubuntu,${short_name},${PWD}/tmp/ubuntu_base_image_${short_name}.tgz,9.000]
+
+ # build warden rosetta stemcell (Apple Silicon / Colima / Lima)
+bundle exec rake stemcell:build[warden,warden,ubuntu,${short_name}-rosetta,${PWD}/tmp/ubuntu_base_image_${short_name}.tgz,9.000]
 ```
 
 When building a vSphere stemcell, you must download `VMware-ovftool-*.bundle`


### PR DESCRIPTION
This is currently Resolute-only functionality, since Resolute needs it for systemd.

I've been seeing some weirdness with monit under rosetta, if we confirm that needs the same multi-architecture approach then we can backport all the rosetta stemcell subtype.