### PR TITLE
Fix test stemcells

### DIFF
--- a/acceptance-tests/ipv4director/smoke/smoke_suite_test.go
+++ b/acceptance-tests/ipv4director/smoke/smoke_suite_test.go
@@ -22,10 +22,12 @@ var _ = BeforeSuite(func() {
 	bosh = testhelpers.NewBOSH()
 	stemcellPath := testhelpers.RequireEnv("STEMCELL_PATH")
 	syslogReleasePath := testhelpers.RequireEnv("SYSLOG_RELEASE_PATH")
+	bpmReleasePath := testhelpers.RequireEnv("BPM_RELEASE_PATH")
 	osConfReleasePath := testhelpers.RequireEnv("OS_CONF_RELEASE_PATH")
 
 	bosh.UploadStemcell(stemcellPath)
 	bosh.UploadRelease(syslogReleasePath)
+	bosh.UploadRelease(bpmReleasePath)
 	bosh.UploadRelease(osConfReleasePath)
 	bosh.SafeDeploy()
 })

--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -508,8 +508,10 @@ jobs:
       - get: bosh-integration-registry-image
       - get: bosh-linux-stemcell-builder
       - get: bosh-deployment
-      - get: syslog-release
       - get: bpm-release
+      - get: syslog-release-src
+        params:
+          submodules: all
       - get: os-conf-release
       - get: stemcell
         passed:
@@ -526,6 +528,22 @@ jobs:
       #@ end
         trigger: true
     - do:
+      - task: build-syslog-dev-release
+        image: bosh-integration-registry-image
+        config:
+          platform: linux
+          inputs:
+          - name: syslog-release-src
+          outputs:
+          - name: syslog-release
+          run:
+            path: /bin/bash
+            args:
+            - -c
+            - |
+              set -eu -o pipefail
+              cd syslog-release-src
+              bosh create-release --force --tarball ../syslog-release/syslog-dev-release.tgz
       - task: deploy-director
         file: bosh-stemcells-ci/ci/tasks/gcp/deploy-director.yml
         image: bosh-integration-registry-image
@@ -577,8 +595,10 @@ jobs:
       - get: bosh-integration-registry-image
       - get: bosh-linux-stemcell-builder
       - get: bosh-deployment
-      - get: syslog-release
       - get: bpm-release
+      - get: syslog-release-src
+        params:
+          submodules: all
       - get: os-conf-release
       - get: stemcell
         passed:
@@ -1787,10 +1807,11 @@ resources:
   source:
     repository: cloudfoundry/bosh
 
-- name: syslog-release
-  type: bosh-io-release
+- name: syslog-release-src
+  type: git
   source:
-    repository: cloudfoundry/syslog-release
+    uri: https://github.com/cloudfoundry/syslog-release
+    branch: main
 
 - name: os-conf-release
   type: bosh-io-release


### PR DESCRIPTION
### temporary change

build a dev syslog-release from source until syslog-release cuts a new stemcell. This is to get https://github.com/cloudfoundry/syslog-release/pull/246. This is a separate commit to make it easy to revert later.

### permanent change

upload bpm-release in the smoke tests as syslog release now requires it