### PR TITLE
Fix smoke suite: upload bpm-release, drop unused os-conf

### DIFF
--- a/acceptance-tests/ipv4director/smoke/smoke_suite_test.go
+++ b/acceptance-tests/ipv4director/smoke/smoke_suite_test.go
@@ -22,11 +22,11 @@ var _ = BeforeSuite(func() {
 	bosh = testhelpers.NewBOSH()
 	stemcellPath := testhelpers.RequireEnv("STEMCELL_PATH")
 	syslogReleasePath := testhelpers.RequireEnv("SYSLOG_RELEASE_PATH")
-	osConfReleasePath := testhelpers.RequireEnv("OS_CONF_RELEASE_PATH")
+	bpmReleasePath := testhelpers.RequireEnv("BPM_RELEASE_PATH")
 
 	bosh.UploadStemcell(stemcellPath)
 	bosh.UploadRelease(syslogReleasePath)
-	bosh.UploadRelease(osConfReleasePath)
+	bosh.UploadRelease(bpmReleasePath)
 	bosh.SafeDeploy()
 })
 


### PR DESCRIPTION
The smoke manifest declares bpm as a required release (added in ba67a704d), but the BeforeSuite was missed in that commit - only the parallel syslogrelease/smoke_suite_test.go was updated. This caused 'Release bpm doesn't exist' during deploy.

While here, drop os-conf upload: the smoke manifest never references os-conf, so uploading it added a redundant compile/upload step.

This should unblock the test-stemcells-ipv4 pipeline.