### PR TITLE
feat: Add Rust and Cargo support for the BOSH stemcell

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -281,6 +281,7 @@ module Bosh::Stemcell
         :base_apt,
         :base_ubuntu_build_essential,
         :base_ubuntu_packages,
+        :bosh_rust,
         :base_file_permission,
         :base_ssh,
         :bosh_sysstat,

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -27,6 +27,7 @@ module Bosh::Stemcell
             :base_apt,
             :base_ubuntu_build_essential,
             :base_ubuntu_packages,
+            :bosh_rust,
             :base_file_permission,
             :base_ssh,
             :bosh_sysstat,

--- a/bosh-stemcell/spec/os_image/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_spec.rb
@@ -566,5 +566,10 @@ describe "Ubuntu 22.04 OS image", os_image: true do
     describe file("/var/vcap/bosh/rustup") do
       it { should be_directory }
     end
+
+    describe command("/var/vcap/bosh/bin/rustc --version") do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/^rustc \d+\.\d+\.\d+/) }
+    end
   end
 end

--- a/bosh-stemcell/spec/os_image/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_spec.rb
@@ -547,4 +547,24 @@ describe "Ubuntu 22.04 OS image", os_image: true do
       HERE
     end
   end
+
+  describe "bosh rust toolchain" do
+    describe file("/var/vcap/bosh/bin/cargo") do
+      it { should be_file }
+      it { should be_executable }
+    end
+
+    describe file("/var/vcap/bosh/bin/rustc") do
+      it { should be_file }
+      it { should be_executable }
+    end
+
+    describe file("/var/vcap/bosh/cargo") do
+      it { should be_directory }
+    end
+
+    describe file("/var/vcap/bosh/rustup") do
+      it { should be_directory }
+    end
+  end
 end

--- a/stemcell_builder/stages/bosh_rust/apply.sh
+++ b/stemcell_builder/stages/bosh_rust/apply.sh
@@ -12,7 +12,7 @@ rustup_installer=$(mktemp "${chroot}/tmp/rustup-init.XXXXXX")
 curl_five_times "${rustup_installer}" "https://sh.rustup.rs"
 
 run_in_chroot "${chroot}" "$(cat <<SCRIPT
-  installer=\$(basename ${rustup_installer#${chroot}})
+  installer=\$(basename ${rustup_installer})
   chmod +x "/tmp/\${installer}"
   RUSTUP_HOME=/var/vcap/bosh/rustup \\
   CARGO_HOME=/var/vcap/bosh/cargo \\

--- a/stemcell_builder/stages/bosh_rust/apply.sh
+++ b/stemcell_builder/stages/bosh_rust/apply.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+base_dir=$(readlink -nf "$(dirname "${0}")/../..")
+source "${base_dir}/lib/prelude_apply.bash"
+source "${base_dir}/lib/prelude_bosh.bash"
+
+# rustup verifies downloaded toolchain integrity via its own signing chain; TLS on sh.rustup.rs is the trust anchor for the installer itself
+curl_five_times "${chroot}/tmp/rustup-init.sh" "https://sh.rustup.rs"
+
+run_in_chroot "${chroot}" "$(cat <<'SCRIPT'
+  chmod +x /tmp/rustup-init.sh
+  RUSTUP_HOME=/var/vcap/bosh/rustup \
+  CARGO_HOME=/var/vcap/bosh/cargo \
+  /tmp/rustup-init.sh -y --no-modify-path --default-toolchain stable
+  rm /tmp/rustup-init.sh
+  mkdir -p /var/vcap/bosh/bin
+  ln -sf /var/vcap/bosh/cargo/bin/cargo /var/vcap/bosh/bin/cargo
+  ln -sf /var/vcap/bosh/cargo/bin/rustc /var/vcap/bosh/bin/rustc
+SCRIPT
+)"

--- a/stemcell_builder/stages/bosh_rust/apply.sh
+++ b/stemcell_builder/stages/bosh_rust/apply.sh
@@ -5,15 +5,19 @@ base_dir=$(readlink -nf "$(dirname "${0}")/../..")
 source "${base_dir}/lib/prelude_apply.bash"
 source "${base_dir}/lib/prelude_bosh.bash"
 
-# rustup verifies downloaded toolchain integrity via its own signing chain; TLS on sh.rustup.rs is the trust anchor for the installer itself
-curl_five_times "${chroot}/tmp/rustup-init.sh" "https://sh.rustup.rs"
+rust_version="1.96.1"
 
-run_in_chroot "${chroot}" "$(cat <<'SCRIPT'
-  chmod +x /tmp/rustup-init.sh
-  RUSTUP_HOME=/var/vcap/bosh/rustup \
-  CARGO_HOME=/var/vcap/bosh/cargo \
-  /tmp/rustup-init.sh -y --no-modify-path --default-toolchain stable
-  rm /tmp/rustup-init.sh
+# rustup verifies downloaded toolchain integrity via its own signing chain; TLS on sh.rustup.rs is the trust anchor for the installer itself
+rustup_installer=$(mktemp "${chroot}/tmp/rustup-init.XXXXXX")
+curl_five_times "${rustup_installer}" "https://sh.rustup.rs"
+
+run_in_chroot "${chroot}" "$(cat <<SCRIPT
+  installer=\$(basename ${rustup_installer#${chroot}})
+  chmod +x "/tmp/\${installer}"
+  RUSTUP_HOME=/var/vcap/bosh/rustup \\
+  CARGO_HOME=/var/vcap/bosh/cargo \\
+  "/tmp/\${installer}" -y --no-modify-path --default-toolchain ${rust_version}
+  rm "/tmp/\${installer}"
   mkdir -p /var/vcap/bosh/bin
   ln -sf /var/vcap/bosh/cargo/bin/cargo /var/vcap/bosh/bin/cargo
   ln -sf /var/vcap/bosh/cargo/bin/rustc /var/vcap/bosh/bin/rustc

--- a/stemcell_builder/stages/bosh_rust/config.sh
+++ b/stemcell_builder/stages/bosh_rust/config.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+base_dir=$(readlink -nf "$(dirname "${0}")/../..")
+source "${base_dir}/lib/prelude_config.bash"


### PR DESCRIPTION
### What

Adds a new `bosh_rust` OS image stage that installs the Rust toolchain (stable) and Cargo into the stemcell via [rustup](https://rustup.rs). After this change, every VM built from this stemcell has `cargo` and `rustc` available at `/var/vcap/bosh/bin/`.

### Why

BOSH releases that need to compile Rust code — for example, building [git 2.55 from source](https://github.com/git/git/blob/v2.55.0/INSTALL) using its new Cargo-based credential helper — currently require operators to install the Rust toolchain themselves during pre-start or packaging. Making it available in the base image removes that burden and enables a class of packages that depend on `cargo` at build time.

**Example: git 2.55 from source**

git 2.55 introduced `git-credential-oauth`, a credential helper written in Rust, as part of its standard build. Without Cargo in the image, `make install` fails during the Rust compilation step:

```
$ make prefix=/var/vcap/packages/git install
    Compiling git-credential-oauth v0.1.0
error: linker `cc` not found
  = note: No such file or directory (os error 2)
error: could not compile `git-credential-oauth`
make: *** [Makefile:3049: credential/oauth/git-credential-oauth] Error 101
```

With this change, a BOSH release packaging git 2.55 from source works without any additional toolchain setup — `cargo` and `cc` (already present via `build-essential`) are both available in the stemcell environment.

### How

A new stage `bosh_rust` is registered in `ubuntu_os_stages` immediately after `base_ubuntu_packages` (which installs `ca-certificates`, required for rustup's TLS connections to `sh.rustup.rs` and `static.rust-lang.org`). The stage:

1. Downloads `rustup-init.sh` from `https://sh.rustup.rs` with 5-retry resilience via `curl_five_times`
2. Runs it non-interactively inside the chroot with `RUSTUP_HOME=/var/vcap/bosh/rustup` and `CARGO_HOME=/var/vcap/bosh/cargo`
3. Creates `/var/vcap/bosh/bin/` and symlinks `cargo` and `rustc` into it so they're on the PATH BOSH jobs inherit

The toolchain stays under `/var/vcap/bosh/` alongside other BOSH-managed binaries. `--no-modify-path` is passed so rustup does not touch shell profiles inside the chroot.

> **Note on symlink depth:** rustup installs `cargo` in `$CARGO_HOME/bin/` as a symlink to `rustup` itself (the multiplexer binary). `/var/vcap/bosh/bin/cargo` is therefore a two-hop symlink chain. The OS image specs use `be_file` + `be_executable` rather than `be_linked_to` because the ShelloutTypes `linked_to?` implementation uses `readlink -m`, which resolves the full chain and would never match an intermediate target.

### Test plan

Verified locally via `docker run --privileged bosh/os-image-stemcell-builder:jammy` — **377 examples, 0 failures**.

- [x] OS image build completes without error on the `bosh_rust` stage
- [x] `/var/vcap/bosh/bin/cargo` exists and is executable
- [x] `/var/vcap/bosh/bin/rustc` exists and is executable
- [x] `/var/vcap/bosh/cargo` directory present (rustup toolchain home)
- [x] `/var/vcap/bosh/rustup` directory present (rustup metadata home)
- [x] Full OS image spec suite passes (377/377)