### PR TITLE
reduce default hardware version for vsphere stemcells

### DIFF
--- a/scripts/repack-helpers/convert-raw-to-vmdk.sh
+++ b/scripts/repack-helpers/convert-raw-to-vmdk.sh
@@ -54,7 +54,7 @@ vm_guestos=ubuntu-64
 
 cat > $ovf/$vm_hostname.vmx <<EOS
 config.version = "8"
-virtualHW.version = "17"
+virtualHW.version = "13"
 floppy0.present = "FALSE"
 nvram = "nvram"
 deploymentPlatform = "windows"

--- a/stemcell_builder/stages/image_ovf_vmx/apply.sh
+++ b/stemcell_builder/stages/image_ovf_vmx/apply.sh
@@ -45,7 +45,7 @@ vm_guestos=ubuntu-64
 
 cat > $ovf/$vm_hostname.vmx <<EOS
 config.version = "8"
-virtualHW.version = "17"
+virtualHW.version = "13"
 floppy0.present = "FALSE"
 nvram = "nvram"
 deploymentPlatform = "windows"


### PR DESCRIPTION
the vsphere CPI allows the HW version to be configurable, but vsphere doesn't support downgrading hw versions. The stemcell HW verison acts as the lower limit. By reducing it, we allow deploying vms from a larger range of hardware versions. The CPI default is still 17.

As validation, I built a stemcell from this branch and deployed the following scenarios, and checked the HW versions:
1. Old vsphere CPI, new stemcell: vms with HW version 13
2. Newer vsphere CPI with defaults, new stemcell: vms with HW version 17 (CPI default)
3. Newer vsphere CPI configured with 13 as default HW version, new stemcell: vms with HW version 13

ai-assisted=yes
[TNZ-113152] EXPLORE and fix: find out if we can unpin vsphere CPI on 3.1

NOTE: this repository uses a "Merge Forward" strategy