### PR TITLE
ci: Use git driver for semver resource

### DIFF
--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -409,16 +409,16 @@ jobs:
         task-output-folder: updated-usn-log
 
 - name: build-os-image
+  serial: true
   plan:
   - put: build-time
   - get: bosh-stemcells-ci
   - get: os-image-stemcell-builder-registry-image
   - get: bosh-linux-stemcell-builder
     trigger: true
-  - get: version
+  - get: os-image-version
     params:
       bump: "major"
-    resource: os-image-version
   - get: usn-log
   - get: stemcell-trigger
     trigger: true
@@ -442,10 +442,10 @@ jobs:
         author_email: (@= data.values.stemcell_details.bot_email @)
         author_name: (@= data.values.stemcell_details.bot_name @)
         message: 'Bump os-image tgz'
-      version: version/version
+      version: os-image-version/version
   - put: os-image-version
     params:
-      file: version/number
+      file: os-image-version/number
 
 - name: test-unit
   plan:
@@ -1658,18 +1658,20 @@ resources:
 - name: version
   type: semver
   source:
-    json_key: ((gcp_json_key))
-    bucket: bosh-core-stemcells-candidate
-    driver: gcs
-    key: bosh-stemcell/(@= data.values.stemcell_details.branch @)/1.x/1.x-version
+    driver: git
+    uri: git@github.com:cloudfoundry/bosh-linux-stemcell-builder
+    branch: release-details
+    file: (@= data.values.stemcell_details.branch @)/release-version
+    private_key: ((github_deploy_key_bosh-linux-stemcell-builder.private_key))
 
 - name: os-image-version
   type: semver
   source:
-    json_key: ((gcp_json_key))
-    bucket: bosh-core-stemcells-candidate
-    driver: gcs
-    key: os-image/(@= data.values.stemcell_details.branch @)/1.x/1.x-version
+    driver: git
+    uri: git@github.com:cloudfoundry/bosh-linux-stemcell-builder
+    branch: release-details
+    file: (@= data.values.stemcell_details.branch @)/os-image-version
+    private_key: ((github_deploy_key_bosh-linux-stemcell-builder.private_key))
 
 - name: bosh-linux-stemcell-builder-push
   type: git


### PR DESCRIPTION
* Switches the version resource to use the git driver, which should be more durable than GCS buckets. The buckets now have a frequent cleanup schedule.
* Removes the os-image-version resource entirely; this does not seem to be referenced by any task, nor is the bucket path referenced anywhere else in Cloud Foundry repos.

NOTE: this repository uses a "Merge Forward" strategy

Changes should be made in the earliest applicable branch, and
merged forward through subsequent branches.
1. PR should be created against the oldest stemcell branch, ex: `ubuntu-<short_name-N>`
2. After this PR has been merged create a PR to merge `ubuntu-<short_name-N>` into `ubuntu-<short_name-N+1>`
3. Repeat as needed for subsequent stemcell line branches

### AI Review Feedback

_All AI review comments (CodeRabbit, and Copilot when assigned) must be resolved before human reviewers will look at the PR. For each comment, either:_
- _Make the suggested change, or_
- _Reply to the comment explaining why it does not apply, then resolve the thread._
