### PR TITLE
Fix GCE terraform region/zone for light stemcell CI pipeline

### DIFF
--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -1453,6 +1453,8 @@ resources:
     vars:
       gce_credentials_json: ((gcp_json_key))
       gce_project_id: ((gcp_project_id))
+      gce_region: europe-north2
+      gce_zone: europe-north2-a
   type: terraform_type
 
 - name: base-oss-google-ubuntu-stemcell

--- a/ci/tasks/light-google/skeletal-deployment.yml
+++ b/ci/tasks/light-google/skeletal-deployment.yml
@@ -19,7 +19,7 @@ resource_pools:
   stemcell:
     url: file://assets/stemcell.tgz
   cloud_properties:
-    machine_type: n1-standard-2
+    machine_type: e2-standard-2
     root_disk_type: pd-standard
     zone: ((gce_zone))
     tags:


### PR DESCRIPTION
## Summary

Two fixes to unblock the failing [\`create-light-google-ubuntu-jammy-1\` CI build #16](https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-jammy/jobs/create-light-google-ubuntu-jammy-1/builds/16):

1. **Add explicit GCE region/zone** — \`light-google-environment-oss\` terraform resource in \`ci/pipeline-template.yml\` was defaulting to \`us-central1-f\`, which returned _"does not have enough resources available to fulfill the request (resource type: compute)"_. Switched to \`europe-north2\` / \`europe-north2-a\`.

2. **Switch machine type \`n1-standard-2\` → \`e2-standard-2\`** — N1 machine types are not available in \`europe-north2\` at all. \`e2-standard-2\` is the equivalent (2 vCPU, 8 GB) and is supported across all \`europe-north2\` zones.

## Files changed

| File | Change |
|------|--------|
| \`ci/pipeline-template.yml\` | Add \`gce_region: europe-north2\`, \`gce_zone: europe-north2-a\` to terraform vars |
| \`ci/tasks/light-google/skeletal-deployment.yml\` | \`machine_type: n1-standard-2\` → \`e2-standard-2\` |

Jira: [TNZ-119889](https://vmw-jira.broadcom.net/browse/TNZ-119889) / [TNZ-116382](https://vmw-jira.broadcom.net/browse/TNZ-116382)

## Test plan

- [ ] Re-run \`create-light-google-ubuntu-jammy-1\` pipeline job to confirm it passes