### PR TITLE
Remove legacy Azure ifupdown configuration

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
@@ -146,22 +146,6 @@ describe "Ubuntu 24.04 stemcell image", stemcell_image: true do
     end
   end
 
-  context "installed by system-azure-network", {
-    exclude_on_alicloud: true,
-    exclude_on_aws: true,
-    exclude_on_cloudstack: true,
-    exclude_on_google: true,
-    exclude_on_vsphere: true,
-    exclude_on_warden: true,
-    exclude_on_openstack: true
-  } do
-    describe file("/etc/network/interfaces") do
-      it { should be_file }
-      its(:content) { should match "auto eth0" }
-      its(:content) { should match "iface eth0 inet dhcp" }
-    end
-  end
-
   context "installed by system_open_vm_tools", {
     exclude_on_alicloud: true,
     exclude_on_aws: true,

--- a/stemcell_builder/stages/system_azure_network/apply.sh
+++ b/stemcell_builder/stages/system_azure_network/apply.sh
@@ -10,12 +10,7 @@ rm -fr $chroot/etc/udev/rules.d/70-persistent-net.rules
 
 # Context on the need to replace the hostname is here:
 # https://github.com/cloudfoundry/bosh/issues/1399
-echo -n "bosh-stemcell" > $chroot/etc/hostname
-
-cat >> $chroot/etc/network/interfaces <<EOS
-auto eth0
-iface eth0 inet dhcp
-EOS
+echo -n "bosh-stemcell" >$chroot/etc/hostname
 
 # The port 65330 is unusable on Azure
 cp $dir/assets/90-azure-sysctl.conf $chroot/etc/sysctl.d


### PR DESCRIPTION
The Azure cloud-init datasource bootstraps access to IMDS and renders the reported NIC configuration through netplan to systemd-networkd. The eth0 DHCP entry in `/etc/network/interfaces` is therefore redundant.

On Noble, ifupdown starts dhcpcd (because dhclient is not installed). This leaves dhcpcd and systemd-networkd managing eth0 concurrently. dhcpcd occupies the DHCPv6 client socket on UDP port 546, causing networkd to fail with "Address already in use" and preventing IPv6 assignment - I discovered this when testing IPv6 related changes on Azure: https://github.com/cloudfoundry/bosh-azure-cpi-release/pull/746.

Therefore, remove the legacy config and its corresponding stemcell test so Azure networking has a single owner.
