### PR TITLE
fix: enable systemd forwarding to syslog

### DIFF
--- a/bosh-stemcell/spec/support/os_image_systemd_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_systemd_shared_examples.rb
@@ -20,6 +20,7 @@ shared_examples_for "a systemd-based OS image" do
     describe file("/etc/systemd/journald.conf.d/00-override.conf") do
       it { should be_file }
       its(:content) { should match(/^Storage=volatile/) }
+      its(:content) { should match(/^ForwardToSyslog=yes/) }
     end
 
     describe file("/etc/systemd/system/rsyslog.service.d/00-override.conf") do

--- a/stemcell_builder/stages/rsyslog_config/assets/journal-override.conf
+++ b/stemcell_builder/stages/rsyslog_config/assets/journal-override.conf
@@ -1,2 +1,3 @@
 [Journal]
 Storage=volatile
+ForwardToSyslog=yes


### PR DESCRIPTION
Make systemd forward logs to syslog. This is breaking the bosh-agent tests which validate that logs flow through syslog to /var/log/bosh-agent.log.