### PR TITLE
Enable UEFI Secure Boot

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -98,6 +98,7 @@ grep
 groff-base
 grub-common
 grub-efi-amd64-bin
+grub-efi-amd64-signed
 grub-gfxpayload-lists
 grub-pc
 grub-pc-bin
@@ -366,6 +367,7 @@ man-db
 mawk
 media-types
 module-assistant
+mokutil
 mount
 ncurses-base
 ncurses-bin
@@ -435,10 +437,12 @@ rsyslog-gnutls
 rsyslog-openssl
 rsyslog-relp
 runit
+sbsigntool
 sed
 sensible-utils
 sgml-base
 shared-mime-info
+shim-signed
 software-properties-common
 strace
 sudo

--- a/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
@@ -83,6 +83,16 @@ describe "Ubuntu 24.04 stemcell image", stemcell_image: true do
       end
     end
 
+    describe file("/boot/efi/boot/grub/grub.cfg") do
+      it { should be_file }
+      its(:content) { should match %r{^set prefix=\(\$root\)'/EFI/grub'$} }
+      its(:content) { should match %r{^configfile \$prefix/grub\.cfg$} }
+
+      it "mirrors the config grub-install wrote to the ESP" do
+        expect(subject.content).to eq(file("/boot/efi/EFI/BOOT/grub.cfg").content)
+      end
+    end
+
     describe file("/boot/grub/menu.lst") do
       before { skip 'until alicloud/aws/openstack stop clobbering the symlink with "update-grub"' }
       it { should be_linked_to("./grub.cfg") }

--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -79,6 +79,9 @@ echo "(hd0) ${device}" > ${image_mount_point}/device.map # fallback for non-UEFI
 run_in_chroot ${image_mount_point} "grub-install --target=x86_64-efi --efi-directory=/boot/efi --boot-directory=/boot/efi/EFI --removable -v --no-floppy ${device}"
 run_in_chroot ${image_mount_point} "grub-install -v --target=i386-pc  --grub-mkdevicemap=/device.map --no-floppy ${device}" # fallback for non-UEFI systems
 
+mkdir -p ${image_mount_point}/boot/efi/boot/grub
+cp ${image_mount_point}/boot/efi/EFI/BOOT/grub.cfg ${image_mount_point}/boot/efi/boot/grub/grub.cfg
+
 grub_suffix=""
 case "${stemcell_infrastructure}" in
 aws)

--- a/stemcell_builder/stages/system_grub/apply.sh
+++ b/stemcell_builder/stages/system_grub/apply.sh
@@ -5,7 +5,7 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-pkg_mgr install grub2 grub-efi-amd64-bin
+pkg_mgr install grub2 grub-efi-amd64-bin grub-efi-amd64-signed shim-signed
 
 # When a kernel is installed, update-grub is run per /etc/kernel-img.conf.
 # It complains when /boot/grub/menu.lst doesn't exist, so create it.


### PR DESCRIPTION
### Summary

Stemcells currently ship an unsigned GRUB, so they cannot boot on a VM where UEFI Secure Boot is enforced (e.g. Azure Secure Boot / Trusted Launch). This installs the signed boot chain and puts GRUB's config where the signed binary looks for it.

The extra grub.cfg is needed, because the signed GRUB binaries have their prefix baked in at build time, and changing it invalidates the signature. With `--removable`, `grub-install` installs `gcdx64.efi.signed` under `EFI/BOOT/grubx64.efi` and that image's prefix is `/boot/grub`, resolved against the partition it was loaded from, i.e. the ESP. It therefore never reads the redirect `grub-install` writes to `EFI/BOOT/grub.cfg`. With no config at the path it does read, GRUB drops into the rescue shell. Copying `grub-install`'s generated redirect to that path fixes it.

### Reviewer Note

This change affects all IaaS and secure boot then works wherever a platform enforces it. Azure Gen2 Trusted Launch is one such case, and is where this was validated. However, it would be good, if someone with access to another IaaS could validate this doesn't break anything.

### Validation

Booted a stemcell built from this branch on an Azure Gen2 Trusted Launch VM with Secure Boot enabled and Standard VM.