### PR TITLE
Fix cis compliance stemcell issues

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -74,6 +74,8 @@ shared_examples_for "every OS image" do
     describe file("/etc/profile.d/01-tmout.sh") do
       it { should be_file }
       it { should be_mode(0o644) }
+      it { should be_owned_by("root") }
+      its(:group) { should eq("root") }
       its(:content) { should match(/^readonly TMOUT=900$/) }
       its(:content) { should match(/^export TMOUT$/) }
     end
@@ -239,7 +241,7 @@ shared_examples_for "every OS image" do
     end
 
     it "sets MaxStartups to 10:30:60" do
-      expect(sshd_config.content).to match(/^MaxStartups 10:30:60$/)
+      expect(sshd_config.content.scan(/^[ \t]*MaxStartups\s+\S+$/)).to contain_exactly("MaxStartups 10:30:60")
     end
 
     it "sets PermitEmptyPasswords to no (stig: V-38614)" do

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -247,7 +247,7 @@ shared_examples_for "every OS image" do
     end
 
     it "sets MaxStartups to 10:30:60 (CIS-5.1.18)" do
-      expect(sshd_config.content.scan(/^[ \t]*MaxStartups\s+\S+$/)).to contain_exactly("MaxStartups 10:30:60")
+      expect(sshd_config.content.scan(/^[ \t]*MaxStartups\s+\S+$/).map(&:strip)).to contain_exactly("MaxStartups 10:30:60")
     end
 
     it "sets PermitEmptyPasswords to no (stig: V-38614)" do

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -30,7 +30,7 @@ shared_examples_for "every OS image" do
       its(:content) { should match(%r{^Defaults\s+logfile=/var/log/sudo\.log$}) }
     end
 
-    describe command("egrep -sh '!use_pty' /etc/sudoers /etc/sudoers.d/* | egrep -v '^#' --") do
+    describe command("egrep -sh '!use_pty' /etc/sudoers /etc/sudoers.d/* | egrep -v '^[[:space:]]*#' --") do
       its(:stdout) { should eq("") }
     end
   end

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -21,7 +21,7 @@ shared_examples_for "every OS image" do
     end
   end
 
-  context "installed by bosh_sudoers" do
+  context "installed by bosh_sudoers (CIS-5.2.2, CIS-5.2.3)" do
     describe file("/etc/sudoers") do
       it { should be_file }
       its(:content) { should match(/%bosh_sudoers ALL=\(ALL\) NOPASSWD: ALL/m) }
@@ -75,13 +75,15 @@ shared_examples_for "every OS image" do
       it { should be_file }
     end
 
-    describe file("/etc/profile.d/01-tmout.sh") do
-      it { should be_file }
-      it { should be_mode(0o644) }
-      it { should be_owned_by("root") }
-      its(:group) { should eq("root") }
-      its(:content) { should match(/^readonly TMOUT=900$/) }
-      its(:content) { should match(/^export TMOUT$/) }
+    context "idle session timeout (CIS-5.4.3.2)" do
+      describe file("/etc/profile.d/01-tmout.sh") do
+        it { should be_file }
+        it { should be_mode(0o644) }
+        it { should be_owned_by("root") }
+        its(:group) { should eq("root") }
+        its(:content) { should match(/^readonly TMOUT=900$/) }
+        its(:content) { should match(/^export TMOUT$/) }
+      end
     end
 
     describe command("grep -q .bashrc /root/.profile") do
@@ -244,7 +246,7 @@ shared_examples_for "every OS image" do
       expect(sshd_config.content).to match(/^MaxAuthTries 3$/)
     end
 
-    it "sets MaxStartups to 10:30:60" do
+    it "sets MaxStartups to 10:30:60 (CIS-5.1.18)" do
       expect(sshd_config.content.scan(/^[ \t]*MaxStartups\s+\S+$/)).to contain_exactly("MaxStartups 10:30:60")
     end
 

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -26,6 +26,8 @@ shared_examples_for "every OS image" do
       it { should be_file }
       its(:content) { should match(/%bosh_sudoers ALL=\(ALL\) NOPASSWD: ALL/m) }
       its(:content) { should match "#includedir /etc/sudoers.d" }
+      its(:content) { should match(/^Defaults\s+use_pty$/) }
+      its(:content) { should match(%r{^Defaults\s+logfile=/var/log/sudo\.log$}) }
     end
   end
 
@@ -67,6 +69,13 @@ shared_examples_for "every OS image" do
 
     describe file("/etc/profile.d/00-bosh-ps1") do
       it { should be_file }
+    end
+
+    describe file("/etc/profile.d/01-tmout.sh") do
+      it { should be_file }
+      it { should be_mode(0o644) }
+      its(:content) { should match(/^readonly TMOUT=900$/) }
+      its(:content) { should match(/^export TMOUT$/) }
     end
 
     describe command("grep -q .bashrc /root/.profile") do
@@ -227,6 +236,10 @@ shared_examples_for "every OS image" do
 
     it "sets MaxAuthTries to 3" do
       expect(sshd_config.content).to match(/^MaxAuthTries 3$/)
+    end
+
+    it "sets MaxStartups to 10:30:100" do
+      expect(sshd_config.content).to match(/^MaxStartups 10:30:100$/)
     end
 
     it "sets PermitEmptyPasswords to no (stig: V-38614)" do

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -238,8 +238,8 @@ shared_examples_for "every OS image" do
       expect(sshd_config.content).to match(/^MaxAuthTries 3$/)
     end
 
-    it "sets MaxStartups to 10:30:100" do
-      expect(sshd_config.content).to match(/^MaxStartups 10:30:100$/)
+    it "sets MaxStartups to 10:30:60" do
+      expect(sshd_config.content).to match(/^MaxStartups 10:30:60$/)
     end
 
     it "sets PermitEmptyPasswords to no (stig: V-38614)" do

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -29,6 +29,10 @@ shared_examples_for "every OS image" do
       its(:content) { should match(/^Defaults\s+use_pty$/) }
       its(:content) { should match(%r{^Defaults\s+logfile=/var/log/sudo\.log$}) }
     end
+
+    describe command("egrep -sh '!use_pty' /etc/sudoers /etc/sudoers.d/* | egrep -v '^#' --") do
+      its(:stdout) { should eq("") }
+    end
   end
 
   context "effective GID for UID vcap" do

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -24,7 +24,6 @@ echo 'X11Forwarding no' >> $chroot/etc/ssh/sshd_config
 sed "/^ *MaxAuthTries/d" -i $chroot/etc/ssh/sshd_config
 echo 'MaxAuthTries 3' >> $chroot/etc/ssh/sshd_config
 
-# CIS 5.1.18 - Ensure SSH MaxStartups is configured
 sed "/^[ \t]*MaxStartups/d" -i "$chroot/etc/ssh/sshd_config"
 echo 'MaxStartups 10:30:60' >> "$chroot/etc/ssh/sshd_config"
 

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -24,6 +24,7 @@ echo 'X11Forwarding no' >> $chroot/etc/ssh/sshd_config
 sed "/^ *MaxAuthTries/d" -i $chroot/etc/ssh/sshd_config
 echo 'MaxAuthTries 3' >> $chroot/etc/ssh/sshd_config
 
+# CIS 5.1.18 - Ensure SSH MaxStartups is configured
 sed "/^[ \t]*MaxStartups/d" -i "$chroot/etc/ssh/sshd_config"
 echo 'MaxStartups 10:30:60' >> "$chroot/etc/ssh/sshd_config"
 

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -25,7 +25,7 @@ sed "/^ *MaxAuthTries/d" -i $chroot/etc/ssh/sshd_config
 echo 'MaxAuthTries 3' >> $chroot/etc/ssh/sshd_config
 
 sed "/^ *MaxStartups/d" -i $chroot/etc/ssh/sshd_config
-echo 'MaxStartups 10:30:100' >> $chroot/etc/ssh/sshd_config
+echo 'MaxStartups 10:30:60' >> $chroot/etc/ssh/sshd_config
 
 sed "/^ *PermitEmptyPasswords/d" -i $chroot/etc/ssh/sshd_config
 echo 'PermitEmptyPasswords no' >> $chroot/etc/ssh/sshd_config

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -24,8 +24,8 @@ echo 'X11Forwarding no' >> $chroot/etc/ssh/sshd_config
 sed "/^ *MaxAuthTries/d" -i $chroot/etc/ssh/sshd_config
 echo 'MaxAuthTries 3' >> $chroot/etc/ssh/sshd_config
 
-sed "/^ *MaxStartups/d" -i $chroot/etc/ssh/sshd_config
-echo 'MaxStartups 10:30:60' >> $chroot/etc/ssh/sshd_config
+sed "/^[ \t]*MaxStartups/d" -i "$chroot/etc/ssh/sshd_config"
+echo 'MaxStartups 10:30:60' >> "$chroot/etc/ssh/sshd_config"
 
 sed "/^ *PermitEmptyPasswords/d" -i $chroot/etc/ssh/sshd_config
 echo 'PermitEmptyPasswords no' >> $chroot/etc/ssh/sshd_config

--- a/stemcell_builder/stages/base_ssh/apply.sh
+++ b/stemcell_builder/stages/base_ssh/apply.sh
@@ -24,6 +24,9 @@ echo 'X11Forwarding no' >> $chroot/etc/ssh/sshd_config
 sed "/^ *MaxAuthTries/d" -i $chroot/etc/ssh/sshd_config
 echo 'MaxAuthTries 3' >> $chroot/etc/ssh/sshd_config
 
+sed "/^ *MaxStartups/d" -i $chroot/etc/ssh/sshd_config
+echo 'MaxStartups 10:30:100' >> $chroot/etc/ssh/sshd_config
+
 sed "/^ *PermitEmptyPasswords/d" -i $chroot/etc/ssh/sshd_config
 echo 'PermitEmptyPasswords no' >> $chroot/etc/ssh/sshd_config
 

--- a/stemcell_builder/stages/bosh_sudoers/apply.sh
+++ b/stemcell_builder/stages/bosh_sudoers/apply.sh
@@ -6,9 +6,9 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
-# enable sudoers.d drop-in support (used by CIS 5.2.2/5.2.3 hardening applied via bosh_users), and make sure we don't break anything
+# enable sudoers.d drop-in support, and make sure we don't break anything
 cp -p "$chroot/etc/sudoers" "$chroot/etc/sudoers.save"
-grep -q '#includedir /etc/sudoers.d' "$chroot/etc/sudoers" || echo '#includedir /etc/sudoers.d' >> "$chroot/etc/sudoers"
+echo '#includedir /etc/sudoers.d' >> "$chroot/etc/sudoers"
 run_in_bosh_chroot $chroot "visudo -c"
 if [ $? -ne 0 ]; then
   echo "ERROR: bad sudoers file"

--- a/stemcell_builder/stages/bosh_sudoers/apply.sh
+++ b/stemcell_builder/stages/bosh_sudoers/apply.sh
@@ -6,7 +6,7 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
-# setup sudoers to use includedir, and make sure we don't break anything
+# enable sudoers.d drop-in support (used by CIS 5.2.2/5.2.3 hardening applied via bosh_users), and make sure we don't break anything
 cp -p "$chroot/etc/sudoers" "$chroot/etc/sudoers.save"
 grep -q '#includedir /etc/sudoers.d' "$chroot/etc/sudoers" || echo '#includedir /etc/sudoers.d' >> "$chroot/etc/sudoers"
 run_in_bosh_chroot $chroot "visudo -c"

--- a/stemcell_builder/stages/bosh_sudoers/apply.sh
+++ b/stemcell_builder/stages/bosh_sudoers/apply.sh
@@ -6,9 +6,9 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
-# enable sudoers.d drop-in support, and make sure we don't break anything
-cp -p "$chroot/etc/sudoers" "$chroot/etc/sudoers.save"
-echo '#includedir /etc/sudoers.d' >> "$chroot/etc/sudoers"
+# setup sudoers to use includedir, and make sure we don't break anything
+cp -p $chroot/etc/sudoers $chroot/etc/sudoers.save
+echo '#includedir /etc/sudoers.d' >> $chroot/etc/sudoers
 run_in_bosh_chroot $chroot "visudo -c"
 if [ $? -ne 0 ]; then
   echo "ERROR: bad sudoers file"

--- a/stemcell_builder/stages/bosh_sudoers/apply.sh
+++ b/stemcell_builder/stages/bosh_sudoers/apply.sh
@@ -7,8 +7,8 @@ source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
 # setup sudoers to use includedir, and make sure we don't break anything
-cp -p $chroot/etc/sudoers $chroot/etc/sudoers.save
-echo '#includedir /etc/sudoers.d' >> $chroot/etc/sudoers
+cp -p "$chroot/etc/sudoers" "$chroot/etc/sudoers.save"
+grep -q '#includedir /etc/sudoers.d' "$chroot/etc/sudoers" || echo '#includedir /etc/sudoers.d' >> "$chroot/etc/sudoers"
 run_in_bosh_chroot $chroot "visudo -c"
 if [ $? -ne 0 ]; then
   echo "ERROR: bad sudoers file"

--- a/stemcell_builder/stages/bosh_users/apply.sh
+++ b/stemcell_builder/stages/bosh_users/apply.sh
@@ -37,7 +37,7 @@ echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/root/.bashrc
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/home/vcap/.bashrc
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/etc/skel/.bashrc
 
-# configure idle session shell timeout (CIS 5.4.3.2)
+# configure idle session shell timeout
 cat << 'EOF' > "$chroot/etc/profile.d/01-tmout.sh"
 readonly TMOUT=900
 export TMOUT

--- a/stemcell_builder/stages/bosh_users/apply.sh
+++ b/stemcell_builder/stages/bosh_users/apply.sh
@@ -38,8 +38,8 @@ echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/home/vcap/.bashrc
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/etc/skel/.bashrc
 
 # configure idle session shell timeout
-cat << 'EOF' > $chroot/etc/profile.d/01-tmout.sh
+cat << 'EOF' > "$chroot/etc/profile.d/01-tmout.sh"
 readonly TMOUT=900
 export TMOUT
 EOF
-chmod 0644 $chroot/etc/profile.d/01-tmout.sh
+chmod 0644 "$chroot/etc/profile.d/01-tmout.sh"

--- a/stemcell_builder/stages/bosh_users/apply.sh
+++ b/stemcell_builder/stages/bosh_users/apply.sh
@@ -37,7 +37,7 @@ echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/root/.bashrc
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/home/vcap/.bashrc
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/etc/skel/.bashrc
 
-# configure idle session shell timeout
+# configure idle session shell timeout (CIS 5.4.3.2)
 cat << 'EOF' > "$chroot/etc/profile.d/01-tmout.sh"
 readonly TMOUT=900
 export TMOUT

--- a/stemcell_builder/stages/bosh_users/apply.sh
+++ b/stemcell_builder/stages/bosh_users/apply.sh
@@ -36,3 +36,10 @@ cp $assets_dir/ps1.sh $chroot/etc/profile.d/00-bosh-ps1
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/root/.bashrc
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/home/vcap/.bashrc
 echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/etc/skel/.bashrc
+
+# configure idle session shell timeout
+cat << 'EOF' > $chroot/etc/profile.d/01-tmout.sh
+readonly TMOUT=900
+export TMOUT
+EOF
+chmod 0644 $chroot/etc/profile.d/01-tmout.sh

--- a/stemcell_builder/stages/bosh_users/assets/sudoers
+++ b/stemcell_builder/stages/bosh_users/assets/sudoers
@@ -24,3 +24,5 @@ root    ALL=(ALL) ALL
 
 # Members of bosh_sudoers do not require password to run sudo commands
 %bosh_sudoers ALL=(ALL) NOPASSWD: ALL
+
+#includedir /etc/sudoers.d

--- a/stemcell_builder/stages/bosh_users/assets/sudoers
+++ b/stemcell_builder/stages/bosh_users/assets/sudoers
@@ -4,6 +4,8 @@
 # Defaults
 
 Defaults        !lecture,tty_tickets,!fqdn
+Defaults        use_pty
+Defaults        logfile=/var/log/sudo.log
 
 # Uncomment to allow members of group sudo to not need a password
 # %sudo ALL=NOPASSWD: ALL

--- a/stemcell_builder/stages/bosh_users/assets/sudoers
+++ b/stemcell_builder/stages/bosh_users/assets/sudoers
@@ -4,9 +4,9 @@
 # Defaults
 
 Defaults        !lecture,tty_tickets,!fqdn
-# CIS 5.2.2
+# Run sudo commands in a dedicated pseudo-terminal
 Defaults        use_pty
-# CIS 5.2.3
+# Log sudo activity to a dedicated log file
 Defaults        logfile=/var/log/sudo.log
 
 # Uncomment to allow members of group sudo to not need a password
@@ -26,5 +26,3 @@ root    ALL=(ALL) ALL
 
 # Members of bosh_sudoers do not require password to run sudo commands
 %bosh_sudoers ALL=(ALL) NOPASSWD: ALL
-
-#includedir /etc/sudoers.d

--- a/stemcell_builder/stages/bosh_users/assets/sudoers
+++ b/stemcell_builder/stages/bosh_users/assets/sudoers
@@ -4,7 +4,9 @@
 # Defaults
 
 Defaults        !lecture,tty_tickets,!fqdn
+# CIS 5.2.2
 Defaults        use_pty
+# CIS 5.2.3
 Defaults        logfile=/var/log/sudo.log
 
 # Uncomment to allow members of group sudo to not need a password


### PR DESCRIPTION
This PR addresses CIS benchmark compliance failures on BOSH stemcells by implementing hardening controls and corresponding test assertions for identified CIS rule IDs.

### Changes are as below

* **CIS 5.1.18 (SSH MaxStartups)**: Added `MaxStartups 10:30:60` in `/etc/ssh/sshd_config` to throttle concurrent unauthenticated SSH connections.
* **CIS 5.2.2 (Sudo use_pty)**: Enabled `Defaults use_pty` in `/etc/sudoers` to ensure sudo commands execute within a pseudo-terminal.
* **CIS 5.2.3 (Sudo logfile)**: Added `Defaults logfile=/var/log/sudo.log` in `/etc/sudoers` for dedicated sudo activity logging.
* **CIS 5.4.3.2 (Shell TMOUT)**: Created `/etc/profile.d/01-tmout.sh` with `readonly TMOUT=900` (declared read-only so a session can't override it) for a 15-minute idle shell session timeout.
* **InSpec Tests**: Added InSpec test assertions verifying all four controls.

### Impact on Stemcell Users

* **SSH**: Throttles unauthenticated connection flooding (>10 concurrent attempts); active logins remain unaffected.
* **Sudo**: Commands run in a pseudo-terminal and log activity to `/var/log/sudo.log`.
* **Sessions**: Inactive shell sessions automatically log out after 15 minutes of inactivity.
