### PR TITLE
ci: configure syslog to use bpm on resolute

### DIFF
--- a/acceptance-tests/ipv4director/smoke/manifest.yml
+++ b/acceptance-tests/ipv4director/smoke/manifest.yml
@@ -32,6 +32,7 @@ instance_groups:
   - name: syslog_forwarder
     release: syslog
     properties:
+      use_bpm: true
       syslog:
         address: 127.0.0.1
         port: 5123

--- a/acceptance-tests/ipv4director/syslogrelease/manifest.yml
+++ b/acceptance-tests/ipv4director/syslogrelease/manifest.yml
@@ -46,5 +46,7 @@ instance_groups:
     release: bpm
   - name: syslog_forwarder
     release: syslog
+    properties:
+      use_bpm: true
     consumes:
       syslog_storer: { from: syslog_storer }


### PR DESCRIPTION
this change only applies to resolute, so making the change there directly.

setting the `use_bpm` config added here: https://github.com/cloudfoundry/syslog-release/commit/73d53d23ce158a6711821f3d68f5dc7174369e21

Testing it out here first (UPDATE: job passed): https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/test-delete-when-finished-resolute-ipv4

ai-assisted=yes
[TNZ-106038] Refactor bosh-agent CI pipeline to run integration tests on all supported stemcell lines (Jammy, Noble, Resolute)

