### PR TITLE
Fix monit api iptables rules to prevent LAST-ACK

### DIFF
--- a/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
+++ b/stemcell_builder/stages/bosh_monit/assets/restrict-monit-api-access
@@ -16,16 +16,22 @@ else
     cgroup_match="--cgroup ${monit_isolation_classid}"
 fi
 
-# Idempotently ensure both iptables rules exist.
-# The ACCEPT rule must be checked/inserted first so it appears above the DROP rule in the chain.
+# Idempotently ensure both iptables rules exist, in the order they must be evaluated. The
+# ESTABLISHED,RELATED ACCEPT has to come BEFORE the cgroup DROP: when a monit client dies
+# abruptly the kernel emits an RST on its behalf which carries no cgroup, so the DROP
+# matches it. If that RST is dropped, monit never learns the connection is dead and is left
+# stuck in LAST-ACK retransmitting -- see d38d7ae39, which added the ACCEPT for this reason.
+#
+# Append (-A), not insert (-I): -I puts a rule at the HEAD, so inserting these in reading
+# order would leave the DROP on top and the ACCEPT unreachable.
 if ! iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
         -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null; then
-    iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+    iptables -t mangle -A POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
         -m state --state ESTABLISHED,RELATED -j ACCEPT
 fi
 
 if ! iptables -t mangle -C POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
         -m cgroup ! ${cgroup_match} -j DROP 2>/dev/null; then
-    iptables -t mangle -I POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
+    iptables -t mangle -A POSTROUTING -d 127.0.0.1 -p tcp --dport 2822 \
         -m cgroup ! ${cgroup_match} -j DROP
 fi


### PR DESCRIPTION
### Description
This PR fixes a regression introduced in commit `4dfe37a31` (Add cgroups v2 support for Jammy stemcells) that causes intermittent `Cannot connect to the monit daemon` errors during BOSH deployments.

```
# cat /var/vcap/bosh/etc/stemcell_version  && echo
1.1123
# sudo iptables -t mangle -L POSTROUTING -n -v --line-numbers
Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
num   pkts bytes target     prot opt in     out     source               destination
1      318 22831 ACCEPT     tcp  --  *      *       0.0.0.0/0            127.0.0.1            tcp dpt:2822 state RELATED,ESTABLISHED
2        0     0 DROP       tcp  --  *      *       0.0.0.0/0            127.0.0.1            tcp dpt:2822 cgroup ! 2958295041
```

```
# cat /var/vcap/bosh/etc/stemcell_version  && echo
1.1298
# sudo iptables -t mangle -L POSTROUTING -n -v --line-numbers
Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
num   pkts bytes target     prot opt in     out     source               destination
1        0     0 DROP       tcp  --  *      *       0.0.0.0/0            127.0.0.1            tcp dpt:2822 cgroup ! 2958295041
2      602 43163 ACCEPT     tcp  --  *      *       0.0.0.0/0            127.0.0.1            tcp dpt:2822 state RELATED,ESTABLISHED
```


**The Bug:**
The previous commit refactored the `iptables` rules in `restrict-monit-api-access` to be idempotent, but accidentally reversed the insertion order. Both rules used `-I` (insert at position 1), which caused the `DROP` rule to be evaluated *before* the `ESTABLISHED,RELATED -j ACCEPT` rule.
Because of this, TCP RESET packets sent by the kernel to clean up orphaned connections were dropped (since the kernel does not belong to the `monit-api-access` cgroup). This left sockets lingering in the `LAST-ACK` state for ~106 seconds. If a subsequent `monit` command was assigned the same ephemeral port, it would fail with a "Connection Refused" error.

This results in deployments failing with:
```
Stopping Monitored Services: Stop all services: Running command: 'monit stop -g vcap', stdout: '', stderr: 'monit-actual: Cannot connect to the monit daemon. Did you start it with http support?
monit-actual: Cannot connect to the monit daemon. Did you start it with http support?
```

We can observe the `LAST-ACK` connections in a real-vm deployment scenario.  In certain CI environments, this makes the deployment fail.

**The Fix:**
This PR updates the script to insert the rules in the correct order


### Testing
Verified on a live VM that:
1. The `iptables` rules are now in the correct order (`ACCEPT` is rule 1, `DROP` is rule 2).
2. We reduced the amount of available ephemeral ports to 5, and ran `bosh stop` and `bosh start` in a loop, and observed several connections stuck in `LAST-ACK` that resulted in some failures (`watch "ss -tan '( sport = :2822 or dport = :2822 )'"`)

### AI analysis of why this happens
Here is the exact sequence of events that causes the kernel to send the TCP RST (which then gets dropped by the firewall):

1. The Keep-Alive Pool
When the BOSH agent polls monit (e.g., during StopAndWait), it makes an HTTP GET request to http://127.0.0.1:2822/_status2.

Because it uses Go's default http.Client, it uses HTTP Keep-Alive. After the BOSH agent receives the XML response, it does not close the TCP connection. Instead, the Go runtime puts that idle TCP connection into a connection pool, hoping to reuse it for the next poll 500ms later.

2. The Server Closes the Connection
monit is a very simple HTTP server. It does not support HTTP Keep-Alive by default, or it has a very aggressive timeout for idle connections.

Shortly after sending the XML response, the monit daemon decides it is done with the transaction and initiates a TCP connection close.

monit sends a TCP FIN packet to the BOSH agent.
The BOSH agent's OS kernel receives the FIN, sends an ACK, and puts the socket into CLOSE-WAIT.
The monit daemon's socket goes into FIN-WAIT-2.
3. The Client Discovers the Dead Connection
Meanwhile, the Go runtime inside the BOSH agent still thinks this connection is sitting happily in its idle connection pool.

When the BOSH agent wakes up 500ms later to poll monit again, the Go runtime pulls that connection out of the pool and tries to write the new HTTP GET request to it.

4. The Kernel Sends the RST
When the Go runtime tries to write data to a socket that the server has already started closing (the socket is in CLOSE-WAIT), the Linux kernel immediately realizes the connection is invalid.

The kernel's TCP stack reacts by aborting the connection. It generates a TCP RST (Reset) packet and sends it to monit to say, "Abort! The application tried to write to a closed pipe!"

5. The Firewall Drops the RST
Because this RST packet is generated asynchronously by the kernel's TCP stack in response to an invalid write, the packet is not tagged with the BOSH agent's cgroup (monit-api-access).

The packet hits the iptables rules. Because the rules are out of order (the DROP rule is evaluated first), the firewall drops the RST packet.

6. The Server Gets Stuck in LAST-ACK
Because the RST packet was dropped, the monit daemon never receives it.

monit eventually sends its final FIN packet, transitioning its socket to LAST-ACK, waiting for an acknowledgment that will never come (because the firewall is dropping it). The socket sits there for ~106 seconds until the kernel's TCP retransmission timer finally gives up and clears it.