### PR TITLE
Fix su and cleanup

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -460,7 +460,10 @@ shared_examples_for "every OS image" do
   describe file("/etc/shadow") do
     it("should be owned by root user (stig: V-38502)") { expect(subject.group).to eq("root") }
     it("should be owned by root group (stig: V-38503)") { expect(subject.group).to eq("root") }
-    it("should have mode 0 (stig: V-38504)") { should be_mode(0o000) }
+    # V-38504 asks for mode 0000, which is not achievable on PAM >= 1.7: unix_chkpwd drops
+    # CAP_DAC_OVERRIDE before reading /etc/shadow, so 0000 breaks `su` outright. 0400 still
+    # denies group and other, which is the intent of the control.
+    it("should have mode 0400 (stig: V-38504)") { should be_mode(0o400) }
 
     context "contains no system users with passwords (stig: V-38496)" do
       describe command("awk -F: '$1 !~ /^root$/ && $1 !~ /^vcap$/ && $2 !~ /^[!*]/ {print $1 \":\" $2}' /etc/shadow") do

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -458,7 +458,7 @@ shared_examples_for "every OS image" do
   end
 
   describe file("/etc/shadow") do
-    it("should be owned by root user (stig: V-38502)") { expect(subject.group).to eq("root") }
+    it("should be owned by root user (stig: V-38502)") { should be_owned_by("root") }
     it("should be owned by root group (stig: V-38503)") { expect(subject.group).to eq("root") }
     # V-38504 asks for mode 0000, which is not achievable on PAM >= 1.7: unix_chkpwd drops
     # CAP_DAC_OVERRIDE before reading /etc/shadow, so 0000 breaks `su` outright. 0400 still

--- a/stemcell_builder/stages/base_file_permission/apply.sh
+++ b/stemcell_builder/stages/base_file_permission/apply.sh
@@ -9,7 +9,11 @@ source $base_dir/lib/prelude_bosh.bash
 chmod 0000 $chroot/etc/gshadow
 chown root:root $chroot/etc/gshadow
 
-chmod 0000 $chroot/etc/shadow
+# PAM >= 1.7 (Ubuntu Resolute) drops CAP_DAC_OVERRIDE in unix_chkpwd before reading
+# /etc/shadow, so mode 0000 makes the file unreadable even for root and breaks `su`
+# (including `su - vcap` from job pre-start scripts). 0400 keeps the file unreadable by
+# group and other while letting root read it via the owner class.
+chmod 0400 $chroot/etc/shadow
 chown root:root $chroot/etc/shadow
 
 restrict_binary_setuid

--- a/stemcell_builder/stages/password_policies/apply.sh
+++ b/stemcell_builder/stages/password_policies/apply.sh
@@ -33,16 +33,6 @@ patch -p1 $chroot/etc/pam.d/common-auth < $assets_dir/ubuntu/common-auth.patch
 strip_trailing_whitespace_from $chroot/etc/pam.d/common-password
 patch -p1 $chroot/etc/pam.d/common-password < $assets_dir/ubuntu/common-password.patch
 
-# libpam-lastlog2 installs pam_lastlog2.so only to the multiarch path
-# (/usr/lib/x86_64-linux-gnu/security/) but PAM's securedir is /usr/lib/security/.
-# Bridge the gap so PAM can load the module referenced above.
-if [ -f "$chroot/usr/lib/x86_64-linux-gnu/security/pam_lastlog2.so" ] && \
-   [ ! -e "$chroot/usr/lib/security/pam_lastlog2.so" ]; then
-  mkdir -p "$chroot/usr/lib/security"
-  ln -sf /usr/lib/x86_64-linux-gnu/security/pam_lastlog2.so \
-      "$chroot/usr/lib/security/pam_lastlog2.so"
-fi
-
 strip_trailing_whitespace_from $chroot/etc/pam.d/login
 patch $chroot/etc/pam.d/login < $assets_dir/ubuntu/login.patch
 


### PR DESCRIPTION
This fixes `su` on Resolute. STIG wants /etc/shadow to be mode 0000 but PAM 1.7.0 drops CAP_DAC_OVERRIDE which means it can't bypass the file permissions being set to unreadable. Setting to 0400 is the lowest permissions that makes su work.

Also two other commits - one fixes up a test assertion and one eliminates a seemingly unnecessary symlink.