### PR TITLE
Restore pam_lastlog2.so securedir symlink

### DIFF
--- a/stemcell_builder/stages/password_policies/apply.sh
+++ b/stemcell_builder/stages/password_policies/apply.sh
@@ -33,6 +33,18 @@ patch -p1 $chroot/etc/pam.d/common-auth < $assets_dir/ubuntu/common-auth.patch
 strip_trailing_whitespace_from $chroot/etc/pam.d/common-password
 patch -p1 $chroot/etc/pam.d/common-password < $assets_dir/ubuntu/common-password.patch
 
+# libpam-lastlog2 installs pam_lastlog2.so only to the multiarch path
+# (e.g. /usr/lib/x86_64-linux-gnu/security/), but PAM's securedir is
+# /usr/lib/security/ -- without this systemd logs:
+#   PAM unable to dlopen(pam_lastlog2.so): /usr/lib/security/pam_lastlog2.so:
+#   cannot open shared object file
+for module in $chroot/usr/lib/*-linux-gnu/security/pam_lastlog2.so; do
+  if [ -f "$module" ] && [ ! -e "$chroot/usr/lib/security/pam_lastlog2.so" ]; then
+    mkdir -p "$chroot/usr/lib/security"
+    ln -sf "${module#$chroot}" "$chroot/usr/lib/security/pam_lastlog2.so"
+  fi
+done
+
 strip_trailing_whitespace_from $chroot/etc/pam.d/login
 patch $chroot/etc/pam.d/login < $assets_dir/ubuntu/login.patch
 


### PR DESCRIPTION
4edcb33 removed it on the premise that PAM's securedir is the multiarch dir. That was wrong -- the strace behind it was taken with the symlink present, so it showed the resolved target rather than the search path. PAM's securedir on Resolute is /usr/lib/security/, and without the symlink systemd logs on every session:

  PAM unable to dlopen(pam_lastlog2.so): /usr/lib/security/pam_lastlog2.so:
  cannot open shared object file: No such file or directory

failing the smoke test that asserts auth.log is free of such errors. The rule is `session optional`, so it degrades to log noise rather than a hard failure.

Restored with the multiarch directory globbed instead of hardcoded to x86_64-linux-gnu, so it also applies on arm64. dpkg-architecture isn't usable here -- dpkg-dev is a dev tool, not part of the base image.
