### PR TITLE
Track newly added CIS test cases in cis_spec.rb whitelist

### DIFF
--- a/bosh-stemcell/spec/stemcells/cis_spec.rb
+++ b/bosh-stemcell/spec/stemcells/cis_spec.rb
@@ -44,8 +44,12 @@ describe "CIS test case verification", {stemcell_image: true, security_spec: tru
       CIS-9.4
       CIS-9.5
       CIS-10.2
+      CIS-5.1.18
+      CIS-5.2.2
+      CIS-5.2.3
       CIS-5.2.12
       CIS-5.2.13
+      CIS-5.4.3.2
     ]
   end
 


### PR DESCRIPTION
## Summary

PR #702 added CIS hardening assertions for SSH `MaxStartups` (`CIS-5.1.18`), sudo `use_pty` (`CIS-5.2.2`), sudo `logfile` (`CIS-5.2.3`), and shell `TMOUT` (`CIS-5.4.3.2`).

These test descriptions were annotated with `(CIS-...)` tags, which are dynamically tracked into `$cis_test_cases` by `spec/support/cis.rb` during spec execution. However, `base_cis_test_cases` in `spec/stemcells/cis_spec.rb` was not updated to include these 4 new test cases, causing CI pipeline verification failures across IAAS builds on `ubuntu-jammy`.

This PR updates `base_cis_test_cases` in `cis_spec.rb` to include all 4 missing CIS rule IDs.
