### PR TITLE
CI: replace usn git resource with partial-clone task

### DIFF
--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -280,7 +280,9 @@ jobs:
       - get: (@= data.values.stemcell_details.os_short_name @)-usn
         version: every
         trigger: true
-      - get: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
+      - task: fetch-usn-gh-json
+        file: bosh-stemcells-ci/ci/tasks/fetch-usn-gh-json.yml
+        image: os-image-stemcell-builder-registry-image
       - get: usn-log
       - get: high-critical-unfound-usns
     - task: check-if-usn-is-in-github
@@ -288,7 +290,6 @@ jobs:
       image: os-image-stemcell-builder-registry-image
       input_mapping:
         usn: (@= data.values.stemcell_details.os_short_name @)-usn
-        usn-gh-json: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
         unfound-usns: high-critical-unfound-usns
       vars:
         image_os_tag: (@= data.values.stemcell_details.os_short_name @)
@@ -302,7 +303,6 @@ jobs:
         image: os-image-stemcell-builder-registry-image
         input_mapping:
           usns: found-usns
-          usn-gh-json: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
         params:
           OS: (@= data.values.stemcell_details.os_short_name @)
         vars:
@@ -322,6 +322,7 @@ jobs:
         task-output-folder: updated-usn-log
 
 - name: check-usn-packages-are-available
+  serial: true
   plan:
     - in_parallel:
       - get: bosh-stemcells-ci
@@ -336,15 +337,14 @@ jobs:
         trigger: true
         passed:
           - process-high-critical-cves
-      - get: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
-        passed:
-          - process-high-critical-cves
+      - task: fetch-usn-gh-json
+        file: bosh-stemcells-ci/ci/tasks/fetch-usn-gh-json.yml
+        image: os-image-stemcell-builder-registry-image
     - task: check-usn-packages
       file: bosh-stemcells-ci/ci/tasks/check-usn-packages.yml
       image: os-image-stemcell-builder-registry-image
       input_mapping:
         usn-log-in: usn-log
-        usn-gh-json: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
       params:
         OS: (@= data.values.stemcell_details.os_short_name @)
       vars:
@@ -371,14 +371,15 @@ jobs:
         version: every
         trigger: true
       - get: usn-log
-      - get: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
+      - task: fetch-usn-gh-json
+        file: bosh-stemcells-ci/ci/tasks/fetch-usn-gh-json.yml
+        image: os-image-stemcell-builder-registry-image
       - get: low-medium-unfound-usns
     - task: check-if-usn-is-in-github
       file: bosh-stemcells-ci/ci/tasks/check-if-usn-is-in-github.yml
       image: os-image-stemcell-builder-registry-image
       input_mapping:
         usn: (@= data.values.stemcell_details.os_short_name @)-usn-low-medium
-        usn-gh-json: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
         unfound-usns: low-medium-unfound-usns
       vars:
         image_os_tag: (@= data.values.stemcell_details.os_short_name @)
@@ -392,7 +393,6 @@ jobs:
         image: os-image-stemcell-builder-registry-image
         input_mapping:
           usns: found-usns
-          usn-gh-json: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
         params:
           OS: (@= data.values.stemcell_details.os_short_name @)
         vars:
@@ -1829,13 +1829,6 @@ resources:
     severities:
     - high
     - critical
-- name: (@= data.values.stemcell_details.os_short_name @)-usn-gh-json
-  type: git
-  source:
-    branch: main
-    uri: https://github.com/canonical/ubuntu-security-notices.git
-    paths:
-    - usn
 - name: slack-alert
   type: slack-notification
   source:

--- a/ci/tasks/fetch-usn-gh-json.sh
+++ b/ci/tasks/fetch-usn-gh-json.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+REPO_PARENT="$( cd "${REPO_ROOT}/.." && pwd )"
+
+if [[ -n "${DEBUG:-}" ]]; then
+  set -x
+fi
+
+GIT_URI="https://github.com/canonical/ubuntu-security-notices.git"
+GIT_BRANCH="main"
+CACHE_REPO="${REPO_PARENT}/usn-gh-json-cache/repo"
+OUTPUT_DIR="${REPO_PARENT}/usn-gh-json"
+
+# Partial (blobless) + shallow + sparse clone: only the usn/ directory's
+# blobs are ever fetched, never osv/ or vex/ (which dwarf usn/ in size).
+# Cached across builds of this job/step (same worker) so warm runs only
+# fetch blobs for files that actually changed since the last run.
+if [[ -d "${CACHE_REPO}/.git" ]]; then
+  echo "cache hit: fetching latest ${GIT_BRANCH}..."
+  # Re-assert sparse-checkout config every run: it's a no-op when already
+  # correct, but self-heals a cache left without it by a run that was
+  # killed between `clone` and `sparse-checkout set` completing - without
+  # this, `reset --hard` below would silently fetch all of vex/ and osv/
+  # (33GB+) since --filter=blob:none only defers blob fetch, it doesn't
+  # skip it.
+  git -C "${CACHE_REPO}" sparse-checkout init --cone
+  git -C "${CACHE_REPO}" sparse-checkout set usn
+  git -C "${CACHE_REPO}" fetch --depth 1 origin "${GIT_BRANCH}"
+  git -C "${CACHE_REPO}" reset --hard "origin/${GIT_BRANCH}"
+else
+  echo "cache miss: performing partial clone of ${GIT_URI}..."
+  mkdir -p "$(dirname "${CACHE_REPO}")"
+  git clone --filter=blob:none --depth 1 --no-checkout --branch "${GIT_BRANCH}" "${GIT_URI}" "${CACHE_REPO}"
+  git -C "${CACHE_REPO}" sparse-checkout init --cone
+  git -C "${CACHE_REPO}" sparse-checkout set usn
+  # `sparse-checkout set` above already materializes the working tree;
+  # this checkout just confirms HEAD is on the right branch (prints
+  # "Already on '<branch>'" - that's expected, not a bug).
+  git -C "${CACHE_REPO}" checkout "${GIT_BRANCH}"
+fi
+
+mkdir -p "${OUTPUT_DIR}/usn"
+rsync -a "${CACHE_REPO}/usn/" "${OUTPUT_DIR}/usn/"

--- a/ci/tasks/fetch-usn-gh-json.yml
+++ b/ci/tasks/fetch-usn-gh-json.yml
@@ -1,0 +1,13 @@
+platform: linux
+
+inputs:
+  - name: bosh-stemcells-ci
+
+outputs:
+  - name: usn-gh-json
+
+caches:
+  - path: usn-gh-json-cache
+
+run:
+  path: bosh-stemcells-ci/ci/tasks/fetch-usn-gh-json.sh


### PR DESCRIPTION
## Summary
- Replace the `(os)-usn-gh-json` git resource with a task
  (`fetch-usn-gh-json`) doing a partial clone (`--filter=blob:none
  --depth 1`) + cone sparse-checkout scoped to `usn/`, cached across
  builds via `caches:` so warm runs do an incremental `fetch` +
  `reset --hard` instead of a full clone.
- Root cause: the stock `git` resource does a plain `git clone`
  regardless of `sparse_paths`/`depth` config - sparse-checkout only
  trims the working-tree checkout, not what's fetched into
  `.git/objects`. `vex/` (23.8GB) and `osv/` (9.8GB) dominate the repo
  at HEAD; `usn/`, the only directory any of the 3 consuming tasks
  reads, is 570MB.
- Benchmarked cold on a real Concourse worker via `fly execute`
  (not a pipeline change):

  | | time | disk |
  |---|---|---|
  | old (plain clone) | 8909s (~2h28m) | 58.5GB |
  | new, cold | 43s | 664MB |
  | new, warm (cache hit) | 2s | - |

  ~207x faster cold, ~88x smaller, effectively free once cached.
- Dropped the resource's `passed: [process-high-critical-cves]` pin on
  `check-usn-packages-are-available` - that job's actual purpose is
  checking USN fix-availability against the *live* apt repo state, so
  always-fetch-latest is correct behavior, not a regression.
- Added `serial: true` to `check-usn-packages-are-available` to prevent
  concurrent builds racing on the same worker-scoped clone cache.