### PR TITLE
CI: Drop USN descriptions from release when too big

### DIFF
--- a/ci/tasks/build-release-metadata.sh
+++ b/ci/tasks/build-release-metadata.sh
@@ -16,19 +16,43 @@ mkdir -p "${REPO_PARENT}/release-metadata"
 echo -n "${OS_NAME} ${OS_VERSION} v$version" > "${REPO_PARENT}/release-metadata/name"
 echo -n "${OS_NAME}-${OS_VERSION}/v$version" > "${REPO_PARENT}/release-metadata/tag"
 
+body_file="${REPO_PARENT}/release-metadata/body"
+usn_log_json_file="${REPO_PARENT}/bosh-linux-stemcell-builder/usn-log.json"
+
 format_usn_log() {
   local usn_data=${1}
+  local include_description=${2}
 
-  jq -r --slurp < "${usn_data}" '.[] |
+  jq -r --slurp --argjson desc "${include_description}" < "${usn_data}" '.[] |
   "
   **Title**: " + .title +"
   **URL**: " + .url +"
-  **Priorities**: " + (.priorities | join(",")) +"
+  **Priorities**: " + (.priorities | join(",")) +
+  (if $desc then "
   **Description**:
-    " + .description +"
+    " + .description else "" end) +"
   **CVEs**:
   " + (.cves | map(" - " + .) | join("\n"))
   '
+}
+
+write_body() {
+  local include_description=${1}
+
+  {
+    echo "## Metadata:"
+    echo "**BOSH Agent Version**: ${bosh_agent_version}"
+    echo "**Kernel Version**: ${kernel_version}"
+
+    if [[ "${OS_NAME}" == "ubuntu" ]]; then
+      echo ""
+      echo "## USNs:"
+      if [[ "${include_description}" != "true" ]]; then
+        echo "_USN descriptions omitted, see the USN URLs below for details._"
+      fi
+      format_usn_log "${usn_log_json_file}" "${include_description}"
+    fi
+  } > "${body_file}"
 }
 
 pushd "${REPO_PARENT}/candidate-stemcell"
@@ -37,15 +61,9 @@ pushd "${REPO_PARENT}/candidate-stemcell"
 popd
 
 bosh_agent_version=$(cat "${REPO_PARENT}/bosh-linux-stemcell-builder/stemcell_builder/stages/bosh_go_agent/assets/bosh-agent-version")
-{
-  echo "## Metadata:"
-  echo "**BOSH Agent Version**: ${bosh_agent_version}"
-  echo "**Kernel Version**: ${kernel_version}"
-} >> "${REPO_PARENT}/release-metadata/body"
 
 if [[ "${OS_NAME}" == "ubuntu" ]]; then
   # Ensure URL for usn-log from metalink exists before attempting to download.
-  usn_log_json_file="${REPO_PARENT}/bosh-linux-stemcell-builder/usn-log.json"
   touch "${usn_log_json_file}"
   usn_metalink_path="${REPO_PARENT}/bosh-linux-stemcell-builder/image-metalinks/${BRANCH}/${OS_NAME}-${OS_VERSION}.meta4"
   if [[ -n "$(meta4 file-urls --metalink "${usn_metalink_path}" --file usn-log.json)" ]]; then
@@ -56,12 +74,15 @@ if [[ "${OS_NAME}" == "ubuntu" ]]; then
       --file usn-log.json \
       "${usn_log_json_file}"
   fi
+fi
 
-  {
-    echo ""
-    echo "## USNs:"
-    format_usn_log "${usn_log_json_file}"
-  } >> "${REPO_PARENT}/release-metadata/body"
+write_body true
+
+# GitHub rejects release bodies over 125,000 characters. wc -c counts bytes, which
+# is >= the character count for UTF-8, so this guard fires early, never late.
+MAX_BODY_LEN=120000
+if [[ $(wc -c < "${body_file}") -gt ${MAX_BODY_LEN} ]]; then
+  write_body false
 fi
 
 echo "" > "${REPO_PARENT}/usn-log/usn-log.json"


### PR DESCRIPTION
We recently ran into a problem where publishing a stemcell failed because our USN resource was broken for a month, and thus we accumulated many many fixed CVES.  So many that we exceeded the allowed length of a github release body.

This commit drops the USN description text in that case.

ref: https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-jammy/jobs/publish-ubuntu-jammy-1/builds/8#L6a80df77:3 (this pr takes it down to ~75k characters)