### PR TITLE
CI: Address USN OVAL feed by release codename

### DIFF
--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -1815,14 +1815,14 @@ resources:
 - name: (@= data.values.stemcell_details.os_short_name @)-usn-low-medium
   type: usn
   source:
-    os: ubuntu-(@= data.values.stemcell_details.os_version @)-lts
+    os: (@= data.values.stemcell_details.os_short_name @)
     priorities:
     - low
     - medium
 - name: (@= data.values.stemcell_details.os_short_name @)-usn
   type: usn
   source:
-    os: ubuntu-(@= data.values.stemcell_details.os_version @)-lts
+    os: (@= data.values.stemcell_details.os_short_name @)
     priorities:
     - high
     - critical


### PR DESCRIPTION
Canonical publishes OVAL data keyed by codename only (com.ubuntu.<codename>.usn.oval.xml.bz2) -- a `ubuntu-<version>-lts` form has never existed upstream. usn-resource carried a hardcoded alias map to translate that form, and it had no 26.04 entry, so both resolute USN resources failed every check with `Unknown os: ubuntu-26.04-lts` and no job in the automatic-triggers group had ever run.

Derive `os` from os_short_name, which is already the codename and already the single source of truth for resource names, input mappings and image_os_tag. That removes the second, independently-derived spelling of the release which caused the divergence, and needs no resource-side table for future stemcell lines.

https://github.com/cloudfoundry/usn-resource/pull/20 will remove the mapping, this is prep for that.