### PR TITLE
CI: Correct resolute major_version to 0

### DIFF
--- a/ci/pipeline-vars.yml
+++ b/ci/pipeline-vars.yml
@@ -3,7 +3,7 @@
 stemcell_details:
   agent_suffix: "" #! empty
   branch: ubuntu-resolute
-  major_version: 1
+  major_version: 0
   os_version: "26.04"
   os_name: ubuntu-resolute
   os_short_name: resolute


### PR DESCRIPTION
resolute publishes 0.x stemcells -- release-details/ubuntu-resolute/ release-version is 0.136.0, and the candidate index holds 0.124 through 0.136 with no 1.x entries. major_version is not cosmetic: it renders the `version: <major>.x` filter on eight metalink candidate/published resources, so at 1 those resources match nothing.

The value arrived as 1 when this file was created by the merge forward from noble on 2026-06-22; every other var in it was adjusted for resolute, this one was not. jammy (1.1390.0) and noble (1.560.0) are correctly at 1, so this stays on the resolute branch and must not merge forward.

The deployed pipeline already runs 0; with this fix the rendered pipeline matches it exactly, so re-setting no longer renames 6 jobs and 16 resources.