### PR TITLE
sudoers: drop redundant tty_tickets, fix dead visudo check

### DIFF
--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -1737,7 +1737,6 @@ resources:
 - name: bosh-linux-stemcell-builder-push-tags
   type: git
   source:
-    fake_param_to_bust_global_resource_cache: true
     private_key: ((github_deploy_key_bosh-linux-stemcell-builder.private_key))
     uri: git@github.com:cloudfoundry/bosh-linux-stemcell-builder
 

--- a/stemcell_builder/stages/bosh_sudoers/apply.sh
+++ b/stemcell_builder/stages/bosh_sudoers/apply.sh
@@ -9,9 +9,9 @@ source $base_dir/lib/prelude_bosh.bash
 # setup sudoers to use includedir, and make sure we don't break anything
 cp -p $chroot/etc/sudoers $chroot/etc/sudoers.save
 echo '#includedir /etc/sudoers.d' >> $chroot/etc/sudoers
-run_in_bosh_chroot $chroot "visudo -c"
-if [ $? -ne 0 ]; then
-  echo "ERROR: bad sudoers file"
+if ! run_in_bosh_chroot $chroot "visudo -c"; then
+  echo "ERROR: bad sudoers file" >&2
+  mv $chroot/etc/sudoers.save $chroot/etc/sudoers
   exit 1
 fi
 rm $chroot/etc/sudoers.save

--- a/stemcell_builder/stages/bosh_users/assets/sudoers
+++ b/stemcell_builder/stages/bosh_users/assets/sudoers
@@ -3,7 +3,7 @@
 # See the man page for details on how to write a sudoers file.
 # Defaults
 
-Defaults        !lecture,tty_tickets,!fqdn
+Defaults        !lecture,!fqdn
 # Run sudo commands in a dedicated pseudo-terminal
 Defaults        use_pty
 # Log sudo activity to a dedicated log file


### PR DESCRIPTION
Ubuntu Resolute ships sudo-rs, which rejects `tty_tickets` outright and fails the bosh_sudoers stage:

    /etc/sudoers:6:26: syntax error: unknown setting: 'tty_tickets'
    visudo: invalid sudoers file

Removing it is a no-op on jammy and noble rather than a concession to sudo-rs. Per-tty credential caching is already the sudo default -- sudoers(5) as shipped in jammy (sudo 1.9.9) documents timestamp_type's "default value is tty" -- and the tty_tickets flag is a deprecated alias for it. So this lands on jammy and merges forward to all three lines instead of diverging per OS.

Also fix the failure branch in bosh_sudoers, which could never run. Under `set -e` a bare `run_in_bosh_chroot ... "visudo -c"` aborts the stage on nonzero exit, so `if [ $? -ne 0 ]` was only ever reached with $? = 0. That is why CI showed raw visudo output and never "ERROR: bad sudoers file". Running visudo as the `if` condition suppresses `set -e` and lets the branch fire, which also makes the sudoers.save copy meaningful -- it is now restored on failure instead of being left behind unused.

Also remove unnecessary fake_param now that there are no overlapping resource definitions.
