### PR TITLE
sudoers: drop logfile directive, unsupported by sudo-rs

### DIFF
--- a/bosh-stemcell/spec/stemcells/cis_spec.rb
+++ b/bosh-stemcell/spec/stemcells/cis_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe "CIS test case verification", {stemcell_image: true, security_spec: true} do
+  # CIS-5.2.3 was removed from ubuntu-resolute, see spec/support/os_image_shared_examples.rb
   let(:base_cis_test_cases) do
     %W[
       CIS-2.18
@@ -44,7 +45,6 @@ describe "CIS test case verification", {stemcell_image: true, security_spec: tru
       CIS-10.2
       CIS-5.1.18
       CIS-5.2.2
-      CIS-5.2.3
       CIS-5.2.12
       CIS-5.2.13
       CIS-5.4.3.2

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -21,13 +21,17 @@ shared_examples_for "every OS image" do
     end
   end
 
-  context "installed by bosh_sudoers (CIS-5.2.2, CIS-5.2.3)" do
+  # CIS-5.2.3 ("ensure sudo log file exists") is deliberately not covered here.
+  # It requires a `Defaults logfile=` directive in sudoers, and sudo-rs -- the
+  # default sudo provider since Resolute -- has no file-logging backend and
+  # rejects the setting outright. sudo activity is logged to the authpriv
+  # syslog facility instead, which rsyslog_config routes to /var/log/auth.log.
+  context "installed by bosh_sudoers (CIS-5.2.2)" do
     describe file("/etc/sudoers") do
       it { should be_file }
       its(:content) { should match(/%bosh_sudoers ALL=\(ALL\) NOPASSWD: ALL/m) }
       its(:content) { should match "#includedir /etc/sudoers.d" }
       its(:content) { should match(/^Defaults\s+use_pty$/) }
-      its(:content) { should match(%r{^Defaults\s+logfile=/var/log/sudo\.log$}) }
     end
 
     describe command("egrep -sh '!use_pty' /etc/sudoers /etc/sudoers.d/* | egrep -v '^[[:space:]]*#' --") do

--- a/stemcell_builder/stages/bosh_users/assets/sudoers
+++ b/stemcell_builder/stages/bosh_users/assets/sudoers
@@ -6,8 +6,6 @@
 Defaults        !lecture,tty_tickets,!fqdn
 # Run sudo commands in a dedicated pseudo-terminal
 Defaults        use_pty
-# Log sudo activity to a dedicated log file
-Defaults        logfile=/var/log/sudo.log
 
 # Uncomment to allow members of group sudo to not need a password
 # %sudo ALL=NOPASSWD: ALL


### PR DESCRIPTION
## Human Summary

Resolute's rust coreutils sudo doesn't support a logfile directive, so removing it.

## AI Summary

sudoers: drop logfile directive, unsupported by sudo-rs Resolute ships sudo-rs as the default sudo provider, which has no file-logging backend and rejects the setting outright:

    /etc/sudoers:10:17: syntax error: unknown setting: 'logfile'
    visudo: invalid sudoers file

sudo activity goes to the authpriv syslog facility, which rsyslog_config already routes to /var/log/auth.log, so the audit trail survives -- but it is syslog-based rather than a dedicated file.

This means CIS-5.2.3 ("ensure sudo log file exists") is no longer satisfied, and it is removed from the test assertions.