### PR TITLE
Resolute - add rosetta variant, fix package list

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -99,9 +99,11 @@ grep
 groff-base
 grub-efi-amd64-bin
 grub-efi-amd64-signed
+grub-efi-amd64-unsigned
 grub-gfxpayload-lists
 grub-pc
 grub-pc-bin
+grub2
 grub2-common
 gzip
 hostname

--- a/bosh-stemcell/spec/os_image/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_spec.rb
@@ -93,11 +93,9 @@ describe "Ubuntu 26.04 OS image", os_image: true do
         it { should be_installed }
       end
     end
-    # ubuntu-noble tested unicode.pf2 and gfxblacklist.txt here, which were
-    # installed by the grub2 meta-package (via grub-common). Resolute installs
-    # only grub-pc-bin and grub-efi-amd64-bin (the bare binaries), which do not
-    # include those files. They are written to /boot/grub/ during grub-install at
-    # stemcell build time, after this OS-image phase.
+    # ubuntu-noble also asserts /boot/grub/unicode.pf2 and gfxblacklist.txt here.
+    # Resolute only asserts menu.lst, which system_grub creates itself; the other
+    # two are not checked in the OS-image phase.
     describe file("/boot/grub/menu.lst") do
       it { should be_file }
     end

--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -3,8 +3,10 @@
 #@yaml/text-templated-strings
 ---
 
-#@ def metalink_resource(IAAS, HYPERVISOR, FIPS=""):
-  name: (@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)
+#! VARIANT shares the plain stemcell's candidate bucket, so it appears in the
+#! resource name and the index path but never in the meta4 filename or bucket.
+#@ def metalink_resource(IAAS, HYPERVISOR, FIPS="", VARIANT=""):
+  name: (@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)(@= VARIANT @)
   type: metalink-repository
   source:
     mirror_files:
@@ -13,7 +15,7 @@
       private_key: ((github_deploy_key_bosh-io-stemcells-core-index.private_key))
     filters:
       - repositorypath: "*/(@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)(@= data.values.stemcell_details.agent_suffix @).meta4"
-    uri: git+ssh://git@github.com:cloudfoundry/bosh-io-stemcells-core-index.git//dev/(@= data.values.stemcell_details.os_name @)(@= FIPS @)/
+    uri: git+ssh://git@github.com:cloudfoundry/bosh-io-stemcells-core-index.git//dev/(@= data.values.stemcell_details.os_name @)(@= FIPS @)(@= VARIANT @)/
     url_handlers:
       - include:
           - (s3|https)://.*
@@ -26,8 +28,8 @@
 #@yaml/text-templated-strings
 ---
 
-#@ def build_stemcell(IAAS, HYPERVISOR, FIPS=""):
-name: build-(@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)
+#@ def build_stemcell(IAAS, HYPERVISOR, FIPS="", VARIANT=""):
+name: build-(@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)(@= VARIANT @)
 serial: true
 plan:
   - in_parallel:
@@ -58,7 +60,7 @@ plan:
       IAAS: #@ IAAS
       OS_NAME: ubuntu
       S3_API_ENDPOINT: storage.googleapis.com
-      OS_VERSION: (@= data.values.stemcell_details.os_short_name @)(@= FIPS @)
+      OS_VERSION: (@= data.values.stemcell_details.os_short_name @)(@= FIPS @)(@= VARIANT @)
       STEMCELL_BUCKET: bosh-core-stemcells-candidate(@= FIPS @)
       GIT_USER_EMAIL: (@= data.values.stemcell_details.bot_email @)
       GIT_USER_NAME: (@= data.values.stemcell_details.bot_name @)
@@ -69,7 +71,7 @@ plan:
     vars:
       image_os_tag: (@= data.values.stemcell_details.os_short_name @)
   - in_parallel:
-      - put: (@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)
+      - put: (@= IAAS @)-(@= HYPERVISOR @)(@= FIPS @)(@= VARIANT @)
         attempts: 3
         params:
           files:
@@ -502,6 +504,9 @@ jobs:
       #@ for iaas in data.values.stemcell_details.include_fips_iaas:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-fips
       #@ end
+      #@ for v in data.values.stemcell_details.include_variant_iaas:
+        - build-(@= v.iaas @)-(@= v.hypervisor @)-(@= v.variant @)
+      #@ end
         resource: version
         trigger: true
       - get: bosh-stemcells-ci
@@ -525,6 +530,9 @@ jobs:
       #@ end
       #@ for iaas in data.values.stemcell_details.include_fips_iaas:
           - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-fips
+      #@ end
+      #@ for v in data.values.stemcell_details.include_variant_iaas:
+          - build-(@= v.iaas @)-(@= v.hypervisor @)-(@= v.variant @)
       #@ end
         trigger: true
     - do:
@@ -589,6 +597,9 @@ jobs:
       #@ for iaas in data.values.stemcell_details.include_fips_iaas:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-fips
       #@ end
+      #@ for v in data.values.stemcell_details.include_variant_iaas:
+        - build-(@= v.iaas @)-(@= v.hypervisor @)-(@= v.variant @)
+      #@ end
         resource: version
         trigger: true
       - get: bosh-stemcells-ci
@@ -612,6 +623,9 @@ jobs:
           #@ end
           #@ for iaas in data.values.stemcell_details.include_fips_iaas:
           - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-fips
+          #@ end
+          #@ for v in data.values.stemcell_details.include_variant_iaas:
+          - build-(@= v.iaas @)-(@= v.hypervisor @)-(@= v.variant @)
           #@ end
         trigger: true
     - do:
@@ -655,6 +669,9 @@ jobs:
 #@ for iaas in data.values.stemcell_details.include_fips_iaas:
 - #@ build_stemcell(iaas.iaas, iaas.hypervisor, "-fips")
 #@ end
+#@ for v in data.values.stemcell_details.include_variant_iaas:
+- #@ build_stemcell(v.iaas, v.hypervisor, "", "-" + v.variant)
+#@ end
 
 - name: bats
   serial: true
@@ -678,6 +695,9 @@ jobs:
       #@ for iaas in data.values.stemcell_details.include_fips_iaas:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-fips
       #@ end
+      #@ for v in data.values.stemcell_details.include_variant_iaas:
+        - build-(@= v.iaas @)-(@= v.hypervisor @)-(@= v.variant @)
+      #@ end
         resource: bosh-linux-stemcell-builder
       - get: version
         passed:
@@ -687,6 +707,9 @@ jobs:
       #@ for iaas in data.values.stemcell_details.include_fips_iaas:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-fips
       #@ end
+      #@ for v in data.values.stemcell_details.include_variant_iaas:
+        - build-(@= v.iaas @)-(@= v.hypervisor @)-(@= v.variant @)
+      #@ end
         resource: version
       - get: build-time
         passed:
@@ -695,6 +718,9 @@ jobs:
       #@ end
       #@ for iaas in data.values.stemcell_details.include_fips_iaas:
         - build-(@= iaas.iaas @)-(@= iaas.hypervisor @)-fips
+      #@ end
+      #@ for v in data.values.stemcell_details.include_variant_iaas:
+        - build-(@= v.iaas @)-(@= v.hypervisor @)-(@= v.variant @)
       #@ end
         trigger: true
     - do:
@@ -1657,6 +1683,9 @@ resources:
 #@ end
 #@ for iaas in data.values.stemcell_details.include_fips_iaas:
 - #@ metalink_resource(iaas.iaas, iaas.hypervisor, "-fips")
+#@ end
+#@ for v in data.values.stemcell_details.include_variant_iaas:
+- #@ metalink_resource(v.iaas, v.hypervisor, "", "-" + v.variant)
 #@ end
 
 - name: os-image-tarball

--- a/ci/pipeline-template.yml
+++ b/ci/pipeline-template.yml
@@ -513,10 +513,8 @@ jobs:
       - get: bosh-integration-registry-image
       - get: bosh-linux-stemcell-builder
       - get: bosh-deployment
+      - get: syslog-release
       - get: bpm-release
-      - get: syslog-release-src
-        params:
-          submodules: all
       - get: os-conf-release
       - get: stemcell
         passed:
@@ -536,22 +534,6 @@ jobs:
       #@ end
         trigger: true
     - do:
-      - task: build-syslog-dev-release
-        image: bosh-integration-registry-image
-        config:
-          platform: linux
-          inputs:
-          - name: syslog-release-src
-          outputs:
-          - name: syslog-release
-          run:
-            path: /bin/bash
-            args:
-            - -c
-            - |
-              set -eu -o pipefail
-              cd syslog-release-src
-              bosh create-release --force --tarball ../syslog-release/syslog-dev-release.tgz
       - task: deploy-director
         file: bosh-stemcells-ci/ci/tasks/gcp/deploy-director.yml
         image: bosh-integration-registry-image
@@ -606,10 +588,8 @@ jobs:
       - get: bosh-integration-registry-image
       - get: bosh-linux-stemcell-builder
       - get: bosh-deployment
+      - get: syslog-release
       - get: bpm-release
-      - get: syslog-release-src
-        params:
-          submodules: all
       - get: os-conf-release
       - get: stemcell
         passed:
@@ -1839,11 +1819,10 @@ resources:
   source:
     repository: cloudfoundry/bosh
 
-- name: syslog-release-src
-  type: git
+- name: syslog-release
+  type: bosh-io-release
   source:
-    uri: https://github.com/cloudfoundry/syslog-release
-    branch: main
+    repository: cloudfoundry/syslog-release
 
 - name: os-conf-release
   type: bosh-io-release

--- a/ci/pipeline-vars.yml
+++ b/ci/pipeline-vars.yml
@@ -22,6 +22,11 @@ stemcell_details:
     {iaas: warden, hypervisor: boshlite}
   ]
   include_fips_iaas: []
+  #! Variant stemcells: same bucket and stemcell line, variant suffixed onto the
+  #! stemcell name. Rosetta ships arm64 binaries for Apple Silicon bosh-lite.
+  include_variant_iaas: [
+    {iaas: warden, hypervisor: boshlite, variant: rosetta}
+  ]
 
 blobstore_types:
 - dav


### PR DESCRIPTION
# Summary

1. Fix some package list changes that a noble merge brought in
2. Add the warden-rosetta variant of the stemcell to CI
3. Stop building syslog from source since the bpm changes have shipped