### PR TITLE
fix(stemcell): drop stale apt lists and caches from the image

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_spec.rb
@@ -496,6 +496,62 @@ describe "Ubuntu 22.04 stemcell image", stemcell_image: true do
     end
   end
 
+  describe "apt state is not shipped in the stemcell" do
+    # restore_apt_sources rewrites sources.list from the build-time snapshot
+    # mirror back to archive.ubuntu.com, which leaves every fetched list keyed
+    # to a source the image no longer references. Apt discards and refetches
+    # them on the first `apt-get update`, so the stage purges them.
+
+    # Everything except the lock file and the two subdirectories should be gone.
+    describe command(
+      "find /var/lib/apt/lists -mindepth 1 " \
+      "! -name lock ! -name partial ! -name auxfiles | wc -l"
+    ) do
+      its(:stdout) { should match(/^0$/) }
+    end
+
+    describe command("ls /var/lib/apt/lists/*_Packages 2>/dev/null | wc -l") do
+      its(:stdout) { should match(/^0$/) }
+    end
+
+    # Regenerated on demand by the next `apt-get update`.
+    describe command("ls /var/cache/apt/*.bin 2>/dev/null | wc -l") do
+      its(:stdout) { should match(/^0$/) }
+    end
+
+    describe command("ls /var/cache/apt/archives/*.deb 2>/dev/null | wc -l") do
+      its(:stdout) { should match(/^0$/) }
+    end
+
+    # Apt recreates a missing subdirectory, but a parent left behind with the
+    # wrong ownership fails `apt-get update` with a confusing permission error.
+    # The stage preserves these in place rather than recreating them, so assert
+    # the modes it inherited are still intact.
+    describe file("/var/lib/apt/lists") do
+      it { should be_directory }
+      it { should be_mode(0o755) }
+      it { should be_owned_by("root") }
+    end
+
+    describe file("/var/lib/apt/lists/partial") do
+      it { should be_directory }
+      it { should be_mode(0o700) }
+      it { should be_owned_by("_apt") }
+    end
+
+    describe file("/var/lib/apt/lists/auxfiles") do
+      it { should be_directory }
+      it { should be_mode(0o755) }
+      it { should be_owned_by("_apt") }
+    end
+
+    # Asserted separately because the find above excludes lock from its count,
+    # so that assertion passes whether or not the file survived.
+    describe file("/var/lib/apt/lists/lock") do
+      it { should be_file }
+    end
+  end
+
   context "installed by system_kernel", exclude_on_fips: true do
     describe package("linux-generic") do
       it { should be_installed }

--- a/stemcell_builder/stages/restore_apt_sources/apply.sh
+++ b/stemcell_builder/stages/restore_apt_sources/apply.sh
@@ -13,3 +13,23 @@ deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe multiverse
 deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe multiverse
 deb http://security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe multiverse
 EOS
+
+# Every file in /var/lib/apt/lists is named for the build-time snapshot mirror
+# that the heredoc above just replaced, so apt discards and refetches all of it
+# on the first `apt-get update` on a running VM. Shipping it costs ~190MB on
+# disk and ~41MB in the stemcell tarball for zero benefit. Same for the binary
+# caches, which apt regenerates on demand.
+#
+# `apt-get clean` first, then the explicit rm: clean can touch cache state
+# itself, and only it knows to empty archives/ and archives/partial/.
+run_in_chroot "$chroot" "apt-get clean"
+
+# lists/ itself and its partial/ and auxfiles/ subdirectories stay. Apt does
+# recreate a missing subdir, but a parent left with the wrong ownership breaks
+# `apt-get update` with a confusing permission error, so leave them in place
+# rather than deleting and recreating with hand-written modes. lock is kept for
+# the same reason. Contents of both subdirs are regenerable and go.
+find "$chroot/var/lib/apt/lists" -mindepth 1 \
+  ! -name lock ! -name partial ! -name auxfiles -delete
+
+rm -f "$chroot"/var/cache/apt/*.bin


### PR DESCRIPTION
## Human Summary

Remove apt caches that we're shipping in the stemcell for no reason.

## AI Summary

restore_apt_sources rewrites sources.list from the build-time snapshot mirror back to archive.ubuntu.com, which leaves every file in /var/lib/apt/lists keyed to a source the image no longer references. Apt discards and refetches all of it on the first `apt-get update`, so the ~190MB on disk (41MB in the tarball) buys nothing and increases the stemcell size..

Purge the lists and the regenerable binary caches in the same stage that creates the mismatch. lists/, its partial/ and auxfiles/ subdirectories and the lock file are preserved in place: apt recreates a missing subdir but a parent left with the wrong ownership fails `apt-get update` with a confusing permission error.