### PR TITLE
fix(stemcell): restore apt sources before image create

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -101,6 +101,7 @@ module Bosh::Stemcell
         bosh_harden
         bosh_openstack_agent_settings
         bosh_clean_ssh
+        restore_apt_sources
         image_create_efi
         image_install_grub
         sbom_create
@@ -119,6 +120,7 @@ module Bosh::Stemcell
         bosh_harden
         bosh_cloudstack_agent_settings
         bosh_clean_ssh
+        restore_apt_sources
         image_create_efi
         image_install_grub
         sbom_create
@@ -135,6 +137,7 @@ module Bosh::Stemcell
         :bosh_harden,
         :bosh_vsphere_agent_settings,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -154,6 +157,7 @@ module Bosh::Stemcell
         :bosh_aws_agent_settings,
         :bosh_clean_ssh,
         :udev_aws_rules,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -172,6 +176,7 @@ module Bosh::Stemcell
         bosh_harden
         bosh_alicloud_agent_settings
         bosh_clean_ssh
+        restore_apt_sources
         image_create_efi
         image_install_grub
         sbom_create
@@ -188,6 +193,7 @@ module Bosh::Stemcell
         :bosh_harden,
         :bosh_google_agent_settings,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -204,6 +210,7 @@ module Bosh::Stemcell
         :bosh_clean,
         :bosh_harden,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -224,6 +231,7 @@ module Bosh::Stemcell
         :bosh_harden,
         :bosh_azure_agent_settings,
         :bosh_clean_ssh,
+        :restore_apt_sources,
         # when adding a stage that changes files in the image, do so before
         # this line.  Image create will make the image so any changes to the
         # filesystem after it won't apply.
@@ -235,8 +243,7 @@ module Bosh::Stemcell
 
     def finish_stemcell_stages
       [
-        :bosh_package_list,
-        :restore_apt_sources
+        :bosh_package_list
       ]
     end
 

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -92,11 +92,11 @@ module Bosh::Stemcell
             :bosh_aws_agent_settings,
             :bosh_clean_ssh,
             :udev_aws_rules,
+            :restore_apt_sources,
             :image_create_efi,
             :image_install_grub,
             :sbom_create,
-            :bosh_package_list,
-            :restore_apt_sources
+            :bosh_package_list
           ]
         }
         let(:aws_package_stemcell_stages) {
@@ -124,11 +124,11 @@ module Bosh::Stemcell
             :bosh_harden,
             :bosh_alicloud_agent_settings,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create_efi,
             :image_install_grub,
             :sbom_create,
-            :bosh_package_list,
-            :restore_apt_sources
+            :bosh_package_list
           ]
         }
 
@@ -158,11 +158,11 @@ module Bosh::Stemcell
             :bosh_harden,
             :bosh_google_agent_settings,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create_efi,
             :image_install_grub,
             :sbom_create,
-            :bosh_package_list,
-            :restore_apt_sources
+            :bosh_package_list
           ]
         }
 
@@ -195,11 +195,11 @@ module Bosh::Stemcell
                                                                       :bosh_harden,
                                                                       :bosh_openstack_agent_settings,
                                                                       :bosh_clean_ssh,
+                                                                      :restore_apt_sources,
                                                                       :image_create_efi,
                                                                       :image_install_grub,
                                                                       :sbom_create,
-                                                                      :bosh_package_list,
-                                                                      :restore_apt_sources
+                                                                      :bosh_package_list
                                                                     ]
                                                                   )
           expect(stage_collection.package_stemcell_stages("qcow2")).to eq(
@@ -227,11 +227,11 @@ module Bosh::Stemcell
                                                                       :bosh_harden,
                                                                       :bosh_cloudstack_agent_settings,
                                                                       :bosh_clean_ssh,
+                                                                      :restore_apt_sources,
                                                                       :image_create_efi,
                                                                       :image_install_grub,
                                                                       :sbom_create,
-                                                                      :bosh_package_list,
-                                                                      :restore_apt_sources
+                                                                      :bosh_package_list
                                                                     ]
                                                                   )
           expect(stage_collection.package_stemcell_stages("qcow2")).to eq(
@@ -257,11 +257,11 @@ module Bosh::Stemcell
                                                                       :bosh_harden,
                                                                       :bosh_vsphere_agent_settings,
                                                                       :bosh_clean_ssh,
+                                                                      :restore_apt_sources,
                                                                       :image_create_efi,
                                                                       :image_install_grub,
                                                                       :sbom_create,
-                                                                      :bosh_package_list,
-                                                                      :restore_apt_sources
+                                                                      :bosh_package_list
                                                                     ]
                                                                   )
           expect(stage_collection.package_stemcell_stages("ovf")).to eq(vmware_package_stemcell_steps)
@@ -282,11 +282,11 @@ module Bosh::Stemcell
             :bosh_harden,
             :bosh_azure_agent_settings,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create_efi,
             :image_install_grub,
             :sbom_create,
-            :bosh_package_list,
-            :restore_apt_sources
+            :bosh_package_list
           ]
         }
 
@@ -312,11 +312,11 @@ module Bosh::Stemcell
             :bosh_clean,
             :bosh_harden,
             :bosh_clean_ssh,
+            :restore_apt_sources,
             :image_create_efi,
             :image_install_grub,
             :sbom_create,
-            :bosh_package_list,
-            :restore_apt_sources
+            :bosh_package_list
           ]
         }
         let(:package_stemcell_stages) {


### PR DESCRIPTION
## Human Summary

A bad merge made it so restore_apt_sources ran after the stemcell chroot had been copied into the efi image, so it had no effect. Move it back to the correct place. This affected Noble and Resolute, Jammy is fine.

## AI Summary

Merge c82bdeecb undid 1e6e978c2, putting :restore_apt_sources back into finish_stemcell_stages. That list is appended after image_create_efi, which rsyncs the chroot into the disk image, so the sources.list rewrite no longer reaches the shipped image.

Warden masks the regression: prepare_files_image_stemcell tars the chroot directly, so it still picks up post-image changes. Every other disk format tars the image built earlier and ships the build-time snapshot mirror instead. Confirmed in the published bosh-stemcell-1.562-vsphere-esxi-ubuntu-noble, whose /etc/apt/sources.list reads

  deb http://snapshot.ubuntu.com/ubuntu/20260901T162110Z noble ...
  deb http://snapshot.ubuntu.com/ubuntu/20260901T162110Z noble-updates ...
  deb http://snapshot.ubuntu.com/ubuntu/20260901T162110Z noble-security ...

pinning those VMs to a frozen package set that breaks outright once the snapshot URL rotates away.

Put the stage back before image_create_efi in every IaaS list, matching ubuntu-jammy.