### PR TITLE
fix(rosetta): clean apt cache and apply retry opts in the rosetta stage

### DIFF
--- a/bosh-stemcell/spec/stemcells/rosetta_spec.rb
+++ b/bosh-stemcell/spec/stemcells/rosetta_spec.rb
@@ -135,4 +135,19 @@ describe "Rosetta Warden Stemcell", stemcell_image: true do
       its(:group) { should eq("shadow") }
     end
   end
+
+  context "the rosetta stage leaves no apt cache behind" do
+    # This stage makes the only apt calls in the builder that bypass pkg_mgr,
+    # which always finishes with `apt-get clean`. Left uncleaned it ships the
+    # regenerated binary caches (~150MB) and every arm64 deb it downloaded.
+    # The arm64 debs are the fingerprint that identifies this stage as the
+    # culprit rather than some earlier one, so assert on them specifically.
+    describe command("ls /var/cache/apt/archives/*_arm64.deb 2>/dev/null | wc -l") do
+      its(:stdout) { should match(/^0$/) }
+    end
+
+    describe command("ls /var/cache/apt/*.bin 2>/dev/null | wc -l") do
+      its(:stdout) { should match(/^0$/) }
+    end
+  end
 end

--- a/stemcell_builder/stages/base_ubuntu_warden_rosetta/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_warden_rosetta/apply.sh
@@ -44,7 +44,7 @@ debs_root="$chroot$debs_dir/root"
 
 # Enable arm64 as a foreign architecture so apt can resolve arm64 packages.
 run_in_chroot $chroot "dpkg --add-architecture arm64"
-run_in_chroot $chroot "apt-get update"
+run_in_chroot $chroot "apt-get $APT_RETRY_OPTS update"
 
 # Install arm64 runtime libraries needed by the arm64 binaries installed below
 # (systemd in Part 4; unix_chkpwd, auditd and logrotate in Part 5 — auditd needs
@@ -77,7 +77,7 @@ arm64_libs="libc6:arm64 \
   libauparse0t64:arm64 \
   libpopt0:arm64"
 
-run_in_chroot $chroot "apt-get install --no-install-recommends --assume-yes $arm64_libs"
+run_in_chroot $chroot "apt-get $APT_RETRY_OPTS install --no-install-recommends --assume-yes $arm64_libs"
 
 # ---------------------------------------------------------------------------
 # Part 2: download every arm64 deb that gets swapped in by hand
@@ -105,7 +105,7 @@ run_in_chroot $chroot "
   rm -rf $debs_dir
   mkdir -p $debs_dir
   cd $debs_dir
-  apt-get download $arm64_download_list
+  apt-get $APT_RETRY_OPTS download $arm64_download_list
 "
 
 # ---------------------------------------------------------------------------
@@ -302,3 +302,13 @@ run_in_chroot $chroot "rm -f $probe_marker"
 # Rosetta handler; letting it run risks deregistering Rosetta and leaving no
 # x86-64 binary in the container executable.
 run_in_chroot "$chroot" "systemctl mask systemd-binfmt.service"
+
+# ---------------------------------------------------------------------------
+# Part 7: apt cleanup
+# ---------------------------------------------------------------------------
+
+# The apt calls above are the only ones in the builder that bypass pkg_mgr,
+# which always finishes with `apt-get clean` (lib/prelude_apply.bash). Without
+# this the stage leaves ~150MB of regenerated pkgcache.bin/srcpkgcache.bin plus
+# the downloaded arm64 debs in the image.
+run_in_chroot $chroot "apt-get clean"


### PR DESCRIPTION
## Human Summary

arm64 packages are installed bypassing our usual pkg_mgr, so it also bypasses the built in `apt-get clean`. So run it in the rosetta stage. It would get cleaned up later, but better to ensure the stage is self contained and mimics other stages.

also make sure apt retries like it does when called through pkg_mgr

## AI Summary

base_ubuntu_warden_rosetta calls apt-get update/install/download directly rather than through pkg_mgr, so it never runs `apt-get clean`. The stage is inserted early in warden_stages and nothing after it touches apt, so a rosetta build ships 150MB of regenerated pkgcache.bin/srcpkgcache.bin and 28 cached arm64 debs. Confirmed in
bosh-stemcell-0.139-warden-boshlite-ubuntu-resolute-rosetta: 158MB under /var/cache/apt, both .bin files present, 28 of 28 archives arm64.

Also pass $APT_RETRY_OPTS to the three bare calls, which prelude_apply documents as applying to every apt-get invocation in the build; without them a transient snapshot.ubuntu.com 503 hard-fails the rosetta build where it would be retried anywhere else.
