### PR TITLE
Mask udevd & chrony on noble warden stemcells

### DIFF
--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -73,5 +73,13 @@ for service in "${rosetta_services[@]}"; do
   cp "$assets_dir/rosetta-compat.conf" "$chroot/etc/systemd/system/${service}.service.d/rosetta-compat.conf"
 done
 
-# Mask systemd-binfmt.service which fails under Rosetta emulation
-run_in_chroot "$chroot" "systemctl mask systemd-binfmt.service"
+# mask units which fail under Rosetta and are not needed in a container image
+warden_masked_units=(
+  systemd-udevd.service
+  chrony.service
+  systemd-binfmt.service
+)
+
+for unit in "${warden_masked_units[@]}"; do
+  run_in_chroot "$chroot" "systemctl mask ${unit}"
+done

--- a/stemcell_builder/stages/base_warden/apply.sh
+++ b/stemcell_builder/stages/base_warden/apply.sh
@@ -66,6 +66,7 @@ rosetta_services=(
   systemd-logind
   systemd-timesyncd
   auditd
+  logrotate
 )
 
 for service in "${rosetta_services[@]}"; do


### PR DESCRIPTION
* udevd and chrony are of no use in containers and break under rosetta so mask them in the warden stage
* logrotate was failing on noble stemcells in docker under rosetta. Add it to the list of services that get reduced security features in containers so they can work under rosetta
