### PR TITLE
Revert :amd64 arch suffix on libgcrypt20-dev and libgpg-error-dev in Noble dpkg list

### DIFF
--- a/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
+++ b/bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt
@@ -199,7 +199,7 @@ libfribidi0:amd64
 libfuse3-3:amd64
 libgcc-13-dev:amd64
 libgcc-s1:amd64
-libgcrypt20-dev:amd64
+libgcrypt20-dev
 libgcrypt20:amd64
 libgdbm-compat4t64:amd64
 libgdbm6t64:amd64
@@ -210,7 +210,7 @@ libglib2.0-data
 libgmp10:amd64
 libgnutls30t64:amd64
 libgomp1:amd64
-libgpg-error-dev:amd64
+libgpg-error-dev
 libgpg-error0:amd64
 libgprofng0:amd64
 libgssapi-krb5-2:amd64


### PR DESCRIPTION
### What is this change about?

PR #693 (`Ubuntu noble - FIPS`, commit `6c8353e0`) modified `bosh-stemcell/spec/assets/dpkg-list-ubuntu.txt`, adding `:amd64` architecture suffixes to `libgcrypt20-dev` and `libgpg-error-dev`.

On standard (non-FIPS) Ubuntu Noble stemcells, `dpkg --get-selections | cut -f1` outputs `libgcrypt20-dev` and `libgpg-error-dev` without the `:amd64` qualifier. Consequently, every standard IaaS build job in the [ubuntu-noble pipeline](https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-noble) (`build-aws-xen-hvm`, `build-azure-hyperv`, `build-google-kvm`, `build-openstack-kvm`, `build-vsphere-esxi`, `build-warden-boshlite`, `build-alicloud-kvm`) failed in RSpec (Build 798) with:

```text
Failures:

  1) Ubuntu 24.04 stemcell image installed packages dpkg --get-selections | cut -f1 | sed -E 's/linux-(.+)-([0-9]+).([0-9]+).([0-9]+)-([0-9]+)/linux-\1-\2.\3/' contains only the base set of packages for alicloud, aws, openstack, warden
     Failure/Error: expect(subject.stdout.split("\n")).to match_array(dpkg_list_ubuntu.concat(dpkg_list_kernel_ubuntu))
     
       the missing elements were: ["libgcrypt20-dev:amd64", "libgpg-error-dev:amd64"]
       the extra elements were:   ["libgcrypt20-dev", "libgpg-error-dev"]
     # ./spec/stemcells/ubuntu_spec.rb:414:in `block (4 levels) in <top (required)>`
```

Reverting the `:amd64` suffix to the unqualified package names in `dpkg-list-ubuntu.txt` restores green verification specs across all standard Noble stemcell builds.

# Merge Forward

- **Oldest applicable branch**: `ubuntu-noble`. `ubuntu-jammy` already lists `libgcrypt20-dev` and `libgpg-error-dev` without the suffix and does not have this regression.
- Once merged to `ubuntu-noble`, this can be merged forward to `ubuntu-resolute`.

### Context
- CI Failure: [bosh.ci.cloudfoundry.org ubuntu-noble pipeline](https://bosh.ci.cloudfoundry.org/teams/stemcell/pipelines/ubuntu-noble)
- Regression introduced by: #693
- Reviewer context: @aramprice @mkocher

### AI Review Feedback

_All AI review comments (CodeRabbit, and Copilot when assigned) must be resolved before human reviewers will look at the PR. For each comment, either:_
- _Make the suggested change, or_
- _Reply to the comment explaining why it does not apply, then resolve the thread._

Made with [Cursor](https://cursor.com)